### PR TITLE
Bump minimum required PHP version to 7.4

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -21,14 +21,13 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.0'
-          - '7.1'
-          - '7.2'
-          - '7.3'
           - '7.4'
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
+          - '8.4'
+          - '8.5'
         dependencies:
           - ''
           - '--prefer-lowest'
@@ -37,20 +36,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Determine Composer version
-        id: composer_version
-        run: |
-          if [[ ${{ matrix.php }} == '7.0' ]]; then
-            echo "version=v1" >> $GITHUB_OUTPUT
-          else
-            echo "version=v2" >> $GITHUB_OUTPUT
-          fi
-
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:${{ steps.composer_version.outputs.version }}
+          tools: composer:v2
 
       - name: Validate composer.json
         run: composer validate --strict

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This package is intended to provide a variety of [SASS-like color manipulation functions](http://sass-lang.com/documentation/Sass/Script/Functions.html).
 
 ## Requirements
-Composer, PHP 7.0 or later.
+Composer, PHP 7.4 or later.
 
 ## Installation
 Install using Composer:

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
     ],
     "homepage": "https://github.com/ssnepenthe/color-utils",
     "require": {
-        "php": "^7.0 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.5.14 || ^9.0",
-        "psy/psysh": "^0.10 || ^0.11",
-        "vimeo/psalm": "^3.0 || ^4.0",
+        "phpunit/phpunit": "^9.0",
+        "psy/psysh": "^0.11",
+        "vimeo/psalm": "^4.0",
         "yoast/phpunit-polyfills": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "psy/psysh": "^0.11",
         "vimeo/psalm": "^4.0",
         "yoast/phpunit-polyfills": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "vimeo/psalm": "^4.0",
-        "yoast/phpunit-polyfills": "^1.0"
+        "yoast/phpunit-polyfills": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/inc/colors.php
+++ b/inc/colors.php
@@ -4,7 +4,6 @@ namespace SSNepenthe\ColorUtils;
 
 /**
  * @param mixed ...$args
- * @return float
  */
 function alpha(...$args) : float
 {
@@ -13,7 +12,6 @@ function alpha(...$args) : float
 
 /**
  * @param mixed ...$args
- * @return int
  */
 function blue(...$args) : int
 {
@@ -22,16 +20,12 @@ function blue(...$args) : int
 
 /**
  * @param mixed ...$args
- * @return float
  */
 function brightness(...$args) : float
 {
     return color(...$args)->getRgb()->calculateBrightness();
 }
 
-/**
- * @return float
- */
 function brightness_difference(Colors\Color $color1, Colors\Color $color2) : float
 {
     return $color1->calculateBrightnessDifferenceWith($color2);
@@ -39,24 +33,17 @@ function brightness_difference(Colors\Color $color1, Colors\Color $color2) : flo
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function color(...$args) : Colors\Color
 {
     return Colors\ColorFactory::fromUnknown(...$args);
 }
 
-/**
- * @return int
- */
 function color_difference(Colors\Color $color1, Colors\Color $color2) : int
 {
     return $color1->calculateColorDifferenceWith($color2);
 }
 
-/**
- * @return float
- */
 function contrast_ratio(Colors\Color $color1, Colors\Color $color2) : float
 {
     return $color1->calculateContrastRatioWith($color2);
@@ -64,7 +51,6 @@ function contrast_ratio(Colors\Color $color1, Colors\Color $color2) : float
 
 /**
  * @param mixed ...$args
- * @return int
  */
 function green(...$args) : int
 {
@@ -73,7 +59,6 @@ function green(...$args) : int
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function hsl(...$args) : Colors\Color
 {
@@ -86,7 +71,6 @@ function hsl(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function hsla(...$args) : Colors\Color
 {
@@ -106,7 +90,6 @@ function hsla(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return float
  */
 function hue(...$args) : float
 {
@@ -115,7 +98,6 @@ function hue(...$args) : float
 
 /**
  * @param mixed ...$args
- * @return boolean
  */
 function is_bright(...$args) : bool
 {
@@ -130,7 +112,6 @@ function is_bright(...$args) : bool
 
 /**
  * @param mixed ...$args
- * @return bool
  */
 function is_light(...$args) : bool
 {
@@ -145,7 +126,6 @@ function is_light(...$args) : bool
 
 /**
  * @param mixed ...$args
- * @return float
  */
 function lightness(...$args) : float
 {
@@ -154,7 +134,6 @@ function lightness(...$args) : float
 
 /**
  * @param mixed ...$args
- * @return bool
  */
 function looks_bright(...$args) : bool
 {
@@ -169,7 +148,6 @@ function looks_bright(...$args) : bool
 
 /**
  * @param mixed ...$args
- * @return string
  */
 function name(...$args) : string
 {
@@ -178,7 +156,6 @@ function name(...$args) : string
 
 /**
  * @param mixed ...$args
- * @return float
  */
 function opacity(...$args) : float
 {
@@ -187,7 +164,6 @@ function opacity(...$args) : float
 
 /**
  * @param mixed ...$args
- * @return float
  */
 function perceived_brightness(...$args) : float
 {
@@ -196,7 +172,6 @@ function perceived_brightness(...$args) : float
 
 /**
  * @param mixed ...$args
- * @return int
  */
 function red(...$args) : int
 {
@@ -205,7 +180,6 @@ function red(...$args) : int
 
 /**
  * @param mixed ...$args
- * @return float
  */
 function relative_luminance(...$args) : float
 {
@@ -214,7 +188,6 @@ function relative_luminance(...$args) : float
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function rgb(...$args) : Colors\Color
 {
@@ -227,7 +200,6 @@ function rgb(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function rgba(...$args) : Colors\Color
 {
@@ -247,7 +219,6 @@ function rgba(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return float
  */
 function saturation(...$args) : float
 {

--- a/inc/colors.php
+++ b/inc/colors.php
@@ -30,8 +30,6 @@ function brightness(...$args) : float
 }
 
 /**
- * @param Colors\Color $color1
- * @param Colors\Color $color2
  * @return float
  */
 function brightness_difference(Colors\Color $color1, Colors\Color $color2) : float
@@ -49,8 +47,6 @@ function color(...$args) : Colors\Color
 }
 
 /**
- * @param Colors\Color $color1
- * @param Colors\Color $color2
  * @return int
  */
 function color_difference(Colors\Color $color1, Colors\Color $color2) : int
@@ -59,8 +55,6 @@ function color_difference(Colors\Color $color1, Colors\Color $color2) : int
 }
 
 /**
- * @param Colors\Color $color1
- * @param Colors\Color $color2
  * @return float
  */
 function contrast_ratio(Colors\Color $color1, Colors\Color $color2) : float

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -3,8 +3,6 @@
 namespace SSNepenthe\ColorUtils;
 
 /**
- * @param array $array
- * @param array $keys
  * @return bool
  */
 function array_contains_all_of(array $array, array $keys) : bool
@@ -13,8 +11,6 @@ function array_contains_all_of(array $array, array $keys) : bool
 }
 
 /**
- * @param array $array
- * @param array $keys
  * @return bool
  */
 function array_contains_one_of(array $array, array $keys) : bool

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -9,7 +9,7 @@ function array_contains_all_of(array $array, array $keys) : bool
 
 function array_contains_one_of(array $array, array $keys) : bool
 {
-    return ! empty(array_intersect($keys, array_keys($array)));
+    return array_intersect($keys, array_keys($array)) !== [];
 }
 
 /**

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -2,17 +2,11 @@
 
 namespace SSNepenthe\ColorUtils;
 
-/**
- * @return bool
- */
 function array_contains_all_of(array $array, array $keys) : bool
 {
     return $keys === array_intersect($keys, array_keys($array));
 }
 
-/**
- * @return bool
- */
 function array_contains_one_of(array $array, array $keys) : bool
 {
     return ! empty(array_intersect($keys, array_keys($array)));
@@ -21,7 +15,6 @@ function array_contains_one_of(array $array, array $keys) : bool
 /**
  * @param mixed $value1
  * @param mixed $value2
- * @return float
  */
 function modulo($value1, $value2) : float
 {
@@ -45,7 +38,6 @@ function restrict($value, $min, $max)
  * @param mixed $value
  * @param mixed $min
  * @param mixed $max
- * @return bool
  */
 function value_is_between($value, $min, $max) : bool
 {
@@ -54,7 +46,6 @@ function value_is_between($value, $min, $max) : bool
 
 /**
  * @param mixed ...$args
- * @return bool
  */
 function _color_args_probably_contain_extra_arg(...$args) : bool
 {

--- a/inc/transformations.php
+++ b/inc/transformations.php
@@ -135,9 +135,6 @@ function lighten(...$args) : Colors\Color
 }
 
 /**
- * @param Colors\Color $color1
- * @param Colors\Color $color2
- * @param int $weight
  * @return Colors\Color
  */
 function mix(

--- a/inc/transformations.php
+++ b/inc/transformations.php
@@ -4,7 +4,6 @@ namespace SSNepenthe\ColorUtils;
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function adjust_color(...$args) : Colors\Color
 {
@@ -17,7 +16,6 @@ function adjust_color(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function adjust_hue(...$args) : Colors\Color
 {
@@ -30,7 +28,6 @@ function adjust_hue(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function change_color(...$args) : Colors\Color
 {
@@ -43,7 +40,6 @@ function change_color(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function complement(...$args) : Colors\Color
 {
@@ -55,7 +51,6 @@ function complement(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function darken(...$args) : Colors\Color
 {
@@ -68,7 +63,6 @@ function darken(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function desaturate(...$args) : Colors\Color
 {
@@ -81,7 +75,6 @@ function desaturate(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function fade_in(...$args) : Colors\Color
 {
@@ -90,7 +83,6 @@ function fade_in(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function fade_out(...$args) : Colors\Color
 {
@@ -99,7 +91,6 @@ function fade_out(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function grayscale(...$args) : Colors\Color
 {
@@ -111,7 +102,6 @@ function grayscale(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function invert(...$args) : Colors\Color
 {
@@ -123,7 +113,6 @@ function invert(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function lighten(...$args) : Colors\Color
 {
@@ -134,9 +123,6 @@ function lighten(...$args) : Colors\Color
     return $transformer->transform($color);
 }
 
-/**
- * @return Colors\Color
- */
 function mix(
     Colors\Color $color1,
     Colors\Color $color2,
@@ -149,7 +135,6 @@ function mix(
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function opacify(...$args) : Colors\Color
 {
@@ -162,7 +147,6 @@ function opacify(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function saturate(...$args) : Colors\Color
 {
@@ -175,7 +159,6 @@ function saturate(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function scale_color(...$args) : Colors\Color
 {
@@ -188,7 +171,6 @@ function scale_color(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function shade(...$args) : Colors\Color
 {
@@ -206,7 +188,6 @@ function shade(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function tint(...$args) : Colors\Color
 {
@@ -224,7 +205,6 @@ function tint(...$args) : Colors\Color
 
 /**
  * @param mixed ...$args
- * @return Colors\Color
  */
 function transparentize(...$args) : Colors\Color
 {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
          beStrictAboutCoversAnnotation="true"
@@ -9,13 +9,12 @@
          beStrictAboutTodoAnnotatedTests="true"
          colors="true"
          verbose="true">
-    <testsuite>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+    <testsuite name="unit">
         <directory suffix="Test.php">tests</directory>
     </testsuite>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,6 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withTypeCoverageLevel(25)
+    ->withTypeCoverageLevel(34)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/inc',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withPhpSets()
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0);

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,6 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withTypeCoverageLevel(2)
+    ->withTypeCoverageLevel(21)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\FuncCall\AddArrayFunctionClosureParamTypeRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -11,6 +12,12 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withTypeCoverageLevel(34)
+    ->withTypeCoverageLevel(59)
     ->withDeadCodeLevel(0)
-    ->withCodeQualityLevel(0);
+    ->withCodeQualityLevel(0)
+    ->withSkip([
+        AddArrayFunctionClosureParamTypeRector::class => [
+            __DIR__ . '/src/Colors/Hsl.php',
+            __DIR__ . '/src/Colors/Rgb.php',
+        ],
+    ]);

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector;
 use Rector\TypeDeclaration\Rector\FuncCall\AddArrayFunctionClosureParamTypeRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -13,13 +14,13 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withCodeQualityLevel(69)
-    ->withPreparedSets(deadCode: true, typeDeclarations: true)
+    ->withPreparedSets(codeQuality: true, deadCode: true, typeDeclarations: true)
     ->withSkip([
         AddArrayFunctionClosureParamTypeRector::class => [
             __DIR__ . '/src/Colors/Hsl.php',
             __DIR__ . '/src/Colors/Rgb.php',
         ],
+        SafeDeclareStrictTypesRector::class,
         UseIdenticalOverEqualWithSameTypeRector::class => [
             __DIR__ . '/src/Colors/BaseColor.php',
         ],

--- a/rector.php
+++ b/rector.php
@@ -12,7 +12,7 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withDeadCodeLevel(23)
+    ->withDeadCodeLevel(53)
     ->withCodeQualityLevel(0)
     ->withPreparedSets(typeDeclarations: true)
     ->withSkip([

--- a/rector.php
+++ b/rector.php
@@ -12,7 +12,7 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withDeadCodeLevel(22)
+    ->withDeadCodeLevel(23)
     ->withCodeQualityLevel(0)
     ->withPreparedSets(typeDeclarations: true)
     ->withSkip([

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector;
 use Rector\TypeDeclaration\Rector\FuncCall\AddArrayFunctionClosureParamTypeRector;
 
 return RectorConfig::configure()
@@ -12,11 +13,14 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withCodeQualityLevel(0)
+    ->withCodeQualityLevel(66)
     ->withPreparedSets(deadCode: true, typeDeclarations: true)
     ->withSkip([
         AddArrayFunctionClosureParamTypeRector::class => [
             __DIR__ . '/src/Colors/Hsl.php',
             __DIR__ . '/src/Colors/Rgb.php',
+        ],
+        UseIdenticalOverEqualWithSameTypeRector::class => [
+            __DIR__ . '/src/Colors/BaseColor.php',
         ],
     ]);

--- a/rector.php
+++ b/rector.php
@@ -13,7 +13,7 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withCodeQualityLevel(66)
+    ->withCodeQualityLevel(69)
     ->withPreparedSets(deadCode: true, typeDeclarations: true)
     ->withSkip([
         AddArrayFunctionClosureParamTypeRector::class => [

--- a/rector.php
+++ b/rector.php
@@ -12,9 +12,8 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withDeadCodeLevel(53)
     ->withCodeQualityLevel(0)
-    ->withPreparedSets(typeDeclarations: true)
+    ->withPreparedSets(deadCode: true, typeDeclarations: true)
     ->withSkip([
         AddArrayFunctionClosureParamTypeRector::class => [
             __DIR__ . '/src/Colors/Hsl.php',

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,6 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withTypeCoverageLevel(0)
+    ->withTypeCoverageLevel(2)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);

--- a/rector.php
+++ b/rector.php
@@ -12,9 +12,9 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withTypeCoverageLevel(59)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0)
+    ->withPreparedSets(typeDeclarations: true)
     ->withSkip([
         AddArrayFunctionClosureParamTypeRector::class => [
             __DIR__ . '/src/Colors/Hsl.php',

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,6 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withTypeCoverageLevel(21)
+    ->withTypeCoverageLevel(25)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);

--- a/rector.php
+++ b/rector.php
@@ -12,7 +12,7 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withDeadCodeLevel(0)
+    ->withDeadCodeLevel(22)
     ->withCodeQualityLevel(0)
     ->withPreparedSets(typeDeclarations: true)
     ->withSkip([

--- a/src/Colors/BaseColor.php
+++ b/src/Colors/BaseColor.php
@@ -62,7 +62,6 @@ abstract class BaseColor implements ColorInterface
     abstract public function toArray() : array;
 
     /**
-     * @param array $channels
      * @return ColorInterface
      */
     abstract public function with(array $channels) : ColorInterface;

--- a/src/Colors/BaseColor.php
+++ b/src/Colors/BaseColor.php
@@ -12,9 +12,6 @@ abstract class BaseColor implements ColorInterface
      */
     protected $alpha = 1.0;
 
-    /**
-     * @return string
-     */
     public function __toString() : string
     {
         return sprintf(
@@ -24,55 +21,31 @@ abstract class BaseColor implements ColorInterface
         );
     }
 
-    /**
-     * @return float
-     */
     public function getAlpha() : float
     {
         return round($this->alpha, 5);
     }
 
-    /**
-     * @return bool
-     */
     public function hasAlpha() : bool
     {
         return 1.0 != $this->getAlpha();
     }
 
-    /**
-     * @return Color
-     */
     public function toColor() : Color
     {
         return new Color($this);
     }
 
-    /**
-     * @return string
-     */
     public function toString() : string
     {
         return $this->__toString();
     }
 
-    /**
-     * @return array
-     */
     abstract public function toArray() : array;
 
-    /**
-     * @return ColorInterface
-     */
     abstract public function with(array $channels) : ColorInterface;
 
-    /**
-     * @return string
-     */
     abstract protected function getStringPrefix() : string;
 
-    /**
-     * @return array
-     */
     abstract protected function toStringifiedArray() : array;
 }

--- a/src/Colors/Color.php
+++ b/src/Colors/Color.php
@@ -50,7 +50,7 @@ class Color
      * @param ColorInterface $color
      * @param string|null $base
      */
-    public function __construct(ColorInterface $color, string $base = null)
+    public function __construct(ColorInterface $color, ?string $base = null)
     {
         $this->representations[] = $color;
 

--- a/src/Colors/Color.php
+++ b/src/Colors/Color.php
@@ -68,17 +68,11 @@ class Color
         }
     }
 
-    /**
-     * @return string
-     */
     public function __toString() : string
     {
         return $this->representations[0]->__toString();
     }
 
-    /**
-     * @return float
-     */
     public function calculateBrightnessDifferenceWith(Color $other) : float
     {
         $brightness1 = $this->getRgb()->calculateBrightness();
@@ -87,9 +81,6 @@ class Color
         return abs($brightness1 - $brightness2);
     }
 
-    /**
-     * @return int
-     */
     public function calculateColorDifferenceWith(Color $other) : int
     {
         $rgb1 = $this->getRgb()->toArray();
@@ -100,9 +91,6 @@ class Color
             + abs($rgb1['blue'] - $rgb2['blue']);
     }
 
-    /**
-     * @return float
-     */
     public function calculateContrastRatioWith(Color $other) : float
     {
         $luminances = [
@@ -114,7 +102,6 @@ class Color
     }
 
     /**
-     * @return ColorInterface
      * @throws RuntimeException
      */
     public function getRepresentation(string $class) : ColorInterface
@@ -128,24 +115,17 @@ class Color
         throw new RuntimeException("No instance of {$class} found");
     }
 
-    /**
-     * @return Hsl
-     */
     public function getHsl() : Hsl
     {
         return $this->getRepresentation(Hsl::class);
     }
 
-    /**
-     * @return Rgb
-     */
     public function getRgb() : Rgb
     {
         return $this->getRepresentation(Rgb::class);
     }
 
     /**
-     * @return Color
      * @throws InvalidArgumentException
      */
     public function with(array $channels) : Color
@@ -185,7 +165,6 @@ class Color
     }
 
     /**
-     * @return ConverterInterface
      * @throws InvalidArgumentException
      */
     protected function makeConverter(ColorInterface $color) : ConverterInterface

--- a/src/Colors/Color.php
+++ b/src/Colors/Color.php
@@ -27,7 +27,7 @@ class Color
      * @return mixed
      * @throws BadMethodCallException
      */
-    public function __call($method, $args)
+    public function __call(string $method, array $args)
     {
         if ('toColor' === $method) {
             // Don't proxy ->toColor() calls, just return this instance.

--- a/src/Colors/Color.php
+++ b/src/Colors/Color.php
@@ -202,11 +202,11 @@ class Color
     protected function makeConverter(ColorInterface $color) : ConverterInterface
     {
         switch (get_class($color)) {
-            case 'SSNepenthe\\ColorUtils\\Colors\\Rgb':
-            case 'SSNepenthe\\ColorUtils\\Colors\\Rgba':
+            case \SSNepenthe\ColorUtils\Colors\Rgb::class:
+            case \SSNepenthe\ColorUtils\Colors\Rgba::class:
                 return new RgbToHsl;
-            case 'SSNepenthe\\ColorUtils\\Colors\\Hsl':
-            case 'SSNepenthe\\ColorUtils\\Colors\\Hsla':
+            case \SSNepenthe\ColorUtils\Colors\Hsl::class:
+            case \SSNepenthe\ColorUtils\Colors\Hsla::class:
                 return new HslToRgb;
             default:
                 // Should never hit this.

--- a/src/Colors/Color.php
+++ b/src/Colors/Color.php
@@ -22,7 +22,6 @@ class Color
     protected $representations = [];
 
     /**
-     * @param string $method
      * @param mixed $args
      * @return mixed
      * @throws BadMethodCallException
@@ -46,10 +45,6 @@ class Color
         ));
     }
 
-    /**
-     * @param ColorInterface $color
-     * @param string|null $base
-     */
     public function __construct(ColorInterface $color, ?string $base = null)
     {
         $this->representations[] = $color;
@@ -82,7 +77,6 @@ class Color
     }
 
     /**
-     * @param Color $other
      * @return float
      */
     public function calculateBrightnessDifferenceWith(Color $other) : float
@@ -94,7 +88,6 @@ class Color
     }
 
     /**
-     * @param Color $other
      * @return int
      */
     public function calculateColorDifferenceWith(Color $other) : int
@@ -108,7 +101,6 @@ class Color
     }
 
     /**
-     * @param Color $other
      * @return float
      */
     public function calculateContrastRatioWith(Color $other) : float
@@ -122,7 +114,6 @@ class Color
     }
 
     /**
-     * @param string $class
      * @return ColorInterface
      * @throws RuntimeException
      */
@@ -154,7 +145,6 @@ class Color
     }
 
     /**
-     * @param array $channels
      * @return Color
      * @throws InvalidArgumentException
      */
@@ -195,7 +185,6 @@ class Color
     }
 
     /**
-     * @param ColorInterface $color
      * @return ConverterInterface
      * @throws InvalidArgumentException
      */

--- a/src/Colors/ColorFactory.php
+++ b/src/Colors/ColorFactory.php
@@ -14,7 +14,6 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class ColorFactory
 {
     /**
-     * @param array $channels
      * @return Color
      * @throws InvalidArgumentException
      */
@@ -94,7 +93,6 @@ class ColorFactory
     }
 
     /**
-     * @param string $color
      * @return Color
      */
     public static function fromString(string $color) : Color

--- a/src/Colors/ColorFactory.php
+++ b/src/Colors/ColorFactory.php
@@ -14,7 +14,6 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class ColorFactory
 {
     /**
-     * @return Color
      * @throws InvalidArgumentException
      */
     public static function fromArray(array $channels) : Color
@@ -51,7 +50,6 @@ class ColorFactory
      * @param float $saturation
      * @param float $lightness
      * @param float $alpha
-     * @return Color
      */
     public static function fromHsla($hue, $saturation, $lightness, $alpha) : Color
     {
@@ -62,7 +60,6 @@ class ColorFactory
      * @param float $hue
      * @param float $saturation
      * @param float $lightness
-     * @return Color
      */
     public static function fromHsl($hue, $saturation, $lightness) : Color
     {
@@ -74,7 +71,6 @@ class ColorFactory
      * @param int $green
      * @param int $blue
      * @param float $alpha
-     * @return Color
      */
     public static function fromRgba($red, $green, $blue, $alpha) : Color
     {
@@ -85,16 +81,12 @@ class ColorFactory
      * @param int $red
      * @param int $green
      * @param int $blue
-     * @return Color
      */
     public static function fromRgb($red, $green, $blue) : Color
     {
         return new Color(new Rgb($red, $green, $blue));
     }
 
-    /**
-     * @return Color
-     */
     public static function fromString(string $color) : Color
     {
         $parser = new DelegatingParser(ParserResolverFactory::all());
@@ -104,7 +96,6 @@ class ColorFactory
 
     /**
      * @param mixed ...$args
-     * @return Color
      * @throws InvalidArgumentException
      */
     public static function fromUnknown(...$args) : Color
@@ -134,7 +125,6 @@ class ColorFactory
      * @param mixed $two
      * @param mixed $three
      * @param mixed $four
-     * @return Color
      * @throws InvalidArgumentException
      */
     public static function fromUnknownFourArgs($one, $two, $three, $four) : Color
@@ -155,7 +145,6 @@ class ColorFactory
 
     /**
      * @param mixed $one
-     * @return Color
      * @throws InvalidArgumentException
      */
     public static function fromUnknownOneArg($one) : Color
@@ -186,7 +175,6 @@ class ColorFactory
      * @param mixed $one
      * @param mixed $two
      * @param mixed $three
-     * @return Color
      * @throws InvalidArgumentException
      */
     public static function fromUnknownThreeArgs($one, $two, $three) : Color
@@ -207,7 +195,6 @@ class ColorFactory
 
     /**
      * @param mixed ...$args
-     * @return bool
      */
     protected static function couldBeHslArgs(...$args) : bool
     {
@@ -220,7 +207,6 @@ class ColorFactory
 
     /**
      * @param mixed ...$args
-     * @return bool
      */
     protected static function couldBeRgbArgs(...$args) : bool
     {

--- a/src/Colors/ColorInterface.php
+++ b/src/Colors/ColorInterface.php
@@ -23,7 +23,6 @@ interface ColorInterface
     public function toString() : string;
 
     /**
-     * @param array $channels
      * @return ColorInterface
      */
     public function with(array $channels) : ColorInterface;

--- a/src/Colors/ColorInterface.php
+++ b/src/Colors/ColorInterface.php
@@ -7,23 +7,11 @@ namespace SSNepenthe\ColorUtils\Colors;
  */
 interface ColorInterface
 {
-    /**
-     * @return array
-     */
     public function toArray() : array;
 
-    /**
-     * @return Color
-     */
     public function toColor() : Color;
 
-    /**
-     * @return string
-     */
     public function toString() : string;
 
-    /**
-     * @return ColorInterface
-     */
     public function with(array $channels) : ColorInterface;
 }

--- a/src/Colors/Hsl.php
+++ b/src/Colors/Hsl.php
@@ -42,7 +42,7 @@ class Hsl extends BaseColor
             /**
              * @return void
              */
-            function ($arg) {
+            function ($arg): void {
                 if (! is_numeric($arg)) {
                     throw new InvalidArgumentException(sprintf(
                         '%s must be called with numeric args',
@@ -60,7 +60,7 @@ class Hsl extends BaseColor
             $args[$i] = restrict(floatval($args[$i]), 0.0, 100.0);
         }
 
-        list($this->hue, $this->saturation, $this->lightness) = $args;
+        [$this->hue, $this->saturation, $this->lightness] = $args;
     }
 
     /**
@@ -151,8 +151,8 @@ class Hsl extends BaseColor
     protected function toStringifiedArray() : array
     {
         $channels = array_map('strval', $this->toArray());
-        $channels['saturation'] = $channels['saturation'] . '%';
-        $channels['lightness'] = $channels['lightness'] . '%';
+        $channels['saturation'] .= '%';
+        $channels['lightness'] .= '%';
 
         return $channels;
     }

--- a/src/Colors/Hsl.php
+++ b/src/Colors/Hsl.php
@@ -111,7 +111,6 @@ class Hsl extends BaseColor
     }
 
     /**
-     * @param array $channels
      * @return ColorInterface
      * @throws InvalidArgumentException
      */

--- a/src/Colors/Hsl.php
+++ b/src/Colors/Hsl.php
@@ -63,25 +63,16 @@ class Hsl extends BaseColor
         [$this->hue, $this->saturation, $this->lightness] = $args;
     }
 
-    /**
-     * @return float
-     */
     public function getHue() : float
     {
         return round($this->hue, 5);
     }
 
-    /**
-     * @return float
-     */
     public function getLightness() : float
     {
         return round($this->lightness, 5);
     }
 
-    /**
-     * @return float
-     */
     public function getSaturation() : float
     {
         return round($this->saturation, 5);
@@ -89,7 +80,6 @@ class Hsl extends BaseColor
 
     /**
      * @param float $threshold
-     * @return bool
      */
     public function isLight($threshold = 50.0) : bool
     {
@@ -98,9 +88,6 @@ class Hsl extends BaseColor
         return $threshold <= $this->getLightness();
     }
 
-    /**
-     * @return array
-     */
     public function toArray() : array
     {
         return [
@@ -111,7 +98,6 @@ class Hsl extends BaseColor
     }
 
     /**
-     * @return ColorInterface
      * @throws InvalidArgumentException
      */
     public function with(array $channels) : ColorInterface
@@ -136,17 +122,11 @@ class Hsl extends BaseColor
         return new Hsl($hue, $saturation, $lightness);
     }
 
-    /**
-     * @return string
-     */
     protected function getStringPrefix() : string
     {
         return 'hsl';
     }
 
-    /**
-     * @return array
-     */
     protected function toStringifiedArray() : array
     {
         $channels = array_map('strval', $this->toArray());

--- a/src/Colors/Hsla.php
+++ b/src/Colors/Hsla.php
@@ -31,9 +31,6 @@ class Hsla extends Hsl
         $this->alpha = restrict(floatval($alpha), 0.0, 1.0);
     }
 
-    /**
-     * @return array
-     */
     public function toArray() : array
     {
         if (! $this->hasAlpha()) {
@@ -43,9 +40,6 @@ class Hsla extends Hsl
         return array_merge(parent::toArray(), ['alpha' => $this->getAlpha()]);
     }
 
-    /**
-     * @return string
-     */
     protected function getStringPrefix() : string
     {
         if (! $this->hasAlpha()) {
@@ -55,9 +49,6 @@ class Hsla extends Hsl
         return 'hsla';
     }
 
-    /**
-     * @return array
-     */
     protected function toStringifiedArray() : array
     {
         $channels = parent::toStringifiedArray();

--- a/src/Colors/Rgb.php
+++ b/src/Colors/Rgb.php
@@ -46,7 +46,7 @@ class Rgb extends BaseColor
             /**
              * @return void
              */
-            function ($arg) {
+            function ($arg): void {
                 if (! is_numeric($arg)) {
                     throw new InvalidArgumentException(sprintf(
                         '%s args must be numeric',
@@ -56,11 +56,9 @@ class Rgb extends BaseColor
             }
         );
 
-        $args = array_map(function ($value) : int {
-            return restrict(intval(round($value)), 0, 255);
-        }, $args);
+        $args = array_map(fn($value): int => restrict(intval(round($value)), 0, 255), $args);
 
-        list($this->red, $this->green, $this->blue) = $args;
+        [$this->red, $this->green, $this->blue] = $args;
     }
 
     /**
@@ -101,7 +99,7 @@ class Rgb extends BaseColor
                 return $value / 12.92;
             }
 
-            return pow((($value + 0.055) / 1.055), 2.4);
+            return (($value + 0.055) / 1.055) ** 2.4;
         }, $this->toArray());
 
         return round(

--- a/src/Colors/Rgb.php
+++ b/src/Colors/Rgb.php
@@ -233,7 +233,6 @@ class Rgb extends BaseColor
     }
 
     /**
-     * @param array $channels
      * @return ColorInterface
      * @throws InvalidArgumentException
      */
@@ -267,7 +266,6 @@ class Rgb extends BaseColor
     }
 
     /**
-     * @param int $int
      * @return string
      */
     protected function intToHexByte(int $int) : string

--- a/src/Colors/Rgb.php
+++ b/src/Colors/Rgb.php
@@ -61,9 +61,6 @@ class Rgb extends BaseColor
         [$this->red, $this->green, $this->blue] = $args;
     }
 
-    /**
-     * @return float
-     */
     public function calculateBrightness() : float
     {
         return round(
@@ -75,9 +72,6 @@ class Rgb extends BaseColor
         );
     }
 
-    /**
-     * @return float
-     */
     public function calculatePerceivedBrightness() : float
     {
         return round(sqrt(
@@ -87,9 +81,6 @@ class Rgb extends BaseColor
         ), 5);
     }
 
-    /**
-     * @return float
-     */
     public function calculateRelativeLuminance() : float
     {
         $rgb = array_map(function ($value) : float {
@@ -110,49 +101,31 @@ class Rgb extends BaseColor
         );
     }
 
-    /**
-     * @return string
-     */
     public function getAlphaByte() : string
     {
         return $this->intToHexByte(intval(round($this->alpha * 255)));
     }
 
-    /**
-     * @return int
-     */
     public function getBlue() : int
     {
         return $this->blue;
     }
 
-    /**
-     * @return string
-     */
     public function getBlueByte() : string
     {
         return $this->intToHexByte($this->getBlue());
     }
 
-    /**
-     * @return int
-     */
     public function getGreen() : int
     {
         return $this->green;
     }
 
-    /**
-     * @return string
-     */
     public function getGreenByte() : string
     {
         return $this->intToHexByte($this->getGreen());
     }
 
-    /**
-     * @return string
-     */
     public function getName() : string
     {
         if ($name = array_search($this->toHexString(), KeywordParser::MAP)) {
@@ -162,17 +135,11 @@ class Rgb extends BaseColor
         return '';
     }
 
-    /**
-     * @return int
-     */
     public function getRed() : int
     {
         return $this->red;
     }
 
-    /**
-     * @return string
-     */
     public function getRedByte() : string
     {
         return $this->intToHexByte($this->getRed());
@@ -180,7 +147,6 @@ class Rgb extends BaseColor
 
     /**
      * @param float $threshold
-     * @return bool
      */
     public function isBright($threshold = 127.5) : bool
     {
@@ -191,7 +157,6 @@ class Rgb extends BaseColor
 
     /**
      * @param float $threshold
-     * @return bool
      */
     public function looksBright($threshold = 127.5) : bool
     {
@@ -200,9 +165,6 @@ class Rgb extends BaseColor
         return $threshold <= $this->calculatePerceivedBrightness();
     }
 
-    /**
-     * @return array
-     */
     public function toArray() : array
     {
         return [
@@ -212,9 +174,6 @@ class Rgb extends BaseColor
         ];
     }
 
-    /**
-     * @return array
-     */
     public function toHexArray() : array
     {
         return [
@@ -224,16 +183,12 @@ class Rgb extends BaseColor
         ];
     }
 
-    /**
-     * @return string
-     */
     public function toHexString() : string
     {
         return '#' . implode('', $this->toHexArray());
     }
 
     /**
-     * @return ColorInterface
      * @throws InvalidArgumentException
      */
     public function with(array $channels) : ColorInterface
@@ -257,25 +212,16 @@ class Rgb extends BaseColor
         return new Rgb($red, $green, $blue);
     }
 
-    /**
-     * @return string
-     */
     protected function getStringPrefix() : string
     {
         return 'rgb';
     }
 
-    /**
-     * @return string
-     */
     protected function intToHexByte(int $int) : string
     {
         return str_pad(dechex($int), 2, '0', STR_PAD_LEFT);
     }
 
-    /**
-     * @return array
-     */
     protected function toStringifiedArray() : array
     {
         return array_map('strval', $this->toArray());

--- a/src/Colors/Rgba.php
+++ b/src/Colors/Rgba.php
@@ -31,9 +31,6 @@ class Rgba extends Rgb
         $this->alpha = restrict(floatval($alpha), 0.0, 1.0);
     }
 
-    /**
-     * @return array
-     */
     public function toArray() : array
     {
         if (! $this->hasAlpha()) {
@@ -43,9 +40,6 @@ class Rgba extends Rgb
         return array_merge(parent::toArray(), ['alpha' => $this->getAlpha()]);
     }
 
-    /**
-     * @return array
-     */
     public function toHexArray() : array
     {
         if (! $this->hasAlpha()) {
@@ -55,9 +49,6 @@ class Rgba extends Rgb
         return array_merge(parent::toHexArray(), ['alpha' => $this->getAlphaByte()]);
     }
 
-    /**
-     * @return string
-     */
     protected function getStringPrefix() : string
     {
         if (! $this->hasAlpha()) {
@@ -67,9 +58,6 @@ class Rgba extends Rgb
         return 'rgba';
     }
 
-    /**
-     * @return array
-     */
     protected function toStringifiedArray() : array
     {
         $channels = parent::toStringifiedArray();

--- a/src/Converters/ConverterInterface.php
+++ b/src/Converters/ConverterInterface.php
@@ -10,7 +10,6 @@ use SSNepenthe\ColorUtils\Colors\ColorInterface;
 interface ConverterInterface
 {
     /**
-     * @param ColorInterface $color
      * @return ColorInterface
      */
     public function convert(ColorInterface $color) : ColorInterface;

--- a/src/Converters/ConverterInterface.php
+++ b/src/Converters/ConverterInterface.php
@@ -9,8 +9,5 @@ use SSNepenthe\ColorUtils\Colors\ColorInterface;
  */
 interface ConverterInterface
 {
-    /**
-     * @return ColorInterface
-     */
     public function convert(ColorInterface $color) : ColorInterface;
 }

--- a/src/Converters/HslToRgb.php
+++ b/src/Converters/HslToRgb.php
@@ -15,7 +15,6 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class HslToRgb implements ConverterInterface
 {
     /**
-     * @return ColorInterface
      * @throws InvalidArgumentException
      */
     public function convert(ColorInterface $color) : ColorInterface

--- a/src/Converters/HslToRgb.php
+++ b/src/Converters/HslToRgb.php
@@ -63,7 +63,7 @@ class HslToRgb implements ConverterInterface
         $tempColors = array_map(fn($colorValue): float => modulo($colorValue, 1), ['red' => $hue + (1 / 3), 'green' => $hue, 'blue' => $hue - (1 / 3)]);
 
         // 6) Actual color values.
-        $colors = array_map(function ($colorValue) use ($temp1, $temp2) : float {
+        $colors = array_map(function (float $colorValue) use ($temp1, $temp2) : float {
             if (6 * $colorValue < 1) {
                 return $temp2 + ($temp1 - $temp2) * 6 * $colorValue;
             }
@@ -80,7 +80,7 @@ class HslToRgb implements ConverterInterface
         }, $tempColors);
 
         // 7) Convert to 8-bit and extract.
-        extract(array_map(fn($color): float => $color * 255, $colors));
+        extract(array_map(fn(float $color): float => $color * 255, $colors));
 
         if (isset($alpha)) {
             return new Rgba($red, $green, $blue, $alpha);

--- a/src/Converters/HslToRgb.php
+++ b/src/Converters/HslToRgb.php
@@ -15,7 +15,6 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class HslToRgb implements ConverterInterface
 {
     /**
-     * @param ColorInterface $color
      * @return ColorInterface
      * @throws InvalidArgumentException
      */

--- a/src/Converters/HslToRgb.php
+++ b/src/Converters/HslToRgb.php
@@ -33,8 +33,8 @@ class HslToRgb implements ConverterInterface
         extract($channels);
 
         // 0) We want saturation and lightness on a scale of 0 - 1.
-        $saturation = $saturation / 100;
-        $lightness = $lightness / 100;
+        $saturation /= 100;
+        $lightness /= 100;
 
         // 1) No saturation means no hue means color is a shade of gray.
         if (0 === $saturation) {
@@ -57,12 +57,10 @@ class HslToRgb implements ConverterInterface
         $temp2 = 2 * $lightness - $temp1;
 
         // 4) Get hue on a scale of 0 - 1.
-        $hue = $hue / 360;
+        $hue /= 360;
 
         // 5) Temporary colors.
-        $tempColors = array_map(function ($colorValue) : float {
-            return modulo($colorValue, 1);
-        }, ['red' => $hue + (1 / 3), 'green' => $hue, 'blue' => $hue - (1 / 3)]);
+        $tempColors = array_map(fn($colorValue): float => modulo($colorValue, 1), ['red' => $hue + (1 / 3), 'green' => $hue, 'blue' => $hue - (1 / 3)]);
 
         // 6) Actual color values.
         $colors = array_map(function ($colorValue) use ($temp1, $temp2) : float {
@@ -82,9 +80,7 @@ class HslToRgb implements ConverterInterface
         }, $tempColors);
 
         // 7) Convert to 8-bit and extract.
-        extract(array_map(function ($color) : float {
-            return $color * 255;
-        }, $colors));
+        extract(array_map(fn($color): float => $color * 255, $colors));
 
         if (isset($alpha)) {
             return new Rgba($red, $green, $blue, $alpha);

--- a/src/Converters/RgbToHsl.php
+++ b/src/Converters/RgbToHsl.php
@@ -15,7 +15,6 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class RgbToHsl implements ConverterInterface
 {
     /**
-     * @param ColorInterface $color
      * @return ColorInterface
      * @throws InvalidArgumentException
      * @throws LogicException

--- a/src/Converters/RgbToHsl.php
+++ b/src/Converters/RgbToHsl.php
@@ -15,7 +15,6 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class RgbToHsl implements ConverterInterface
 {
     /**
-     * @return ColorInterface
      * @throws InvalidArgumentException
      * @throws LogicException
      */

--- a/src/Converters/RgbToHsl.php
+++ b/src/Converters/RgbToHsl.php
@@ -34,9 +34,7 @@ class RgbToHsl implements ConverterInterface
         extract($channels);
 
         // 1) Get RGB values in a range of 0-1.
-        list($red, $green, $blue) = array_map(function ($value) : float {
-            return $value / 255;
-        }, [$red, $green, $blue]);
+        [$red, $green, $blue] = array_map(fn($value): float => $value / 255, [$red, $green, $blue]);
 
         // 2) Find the max and min values from $red, $green, $blue.
         $max = max($red, $green, $blue);

--- a/src/Parsers/DelegatingParser.php
+++ b/src/Parsers/DelegatingParser.php
@@ -9,10 +9,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
  */
 class DelegatingParser implements ParserInterface
 {
-    /**
-     * @var ParserResolverInterface
-     */
-    protected $resolver;
+    protected ParserResolverInterface $resolver;
 
     /**
      * @param ParserResolverInterface $resolver

--- a/src/Parsers/DelegatingParser.php
+++ b/src/Parsers/DelegatingParser.php
@@ -17,7 +17,6 @@ class DelegatingParser implements ParserInterface
     }
 
     /**
-     * @return array
      * @throws InvalidArgumentException
      */
     public function parse(string $color) : array
@@ -33,9 +32,6 @@ class DelegatingParser implements ParserInterface
         return $parser->parse($color);
     }
 
-    /**
-     * @return bool
-     */
     public function supports(string $color) : bool
     {
         return false !== $this->resolver->resolve($color);

--- a/src/Parsers/DelegatingParser.php
+++ b/src/Parsers/DelegatingParser.php
@@ -11,16 +11,12 @@ class DelegatingParser implements ParserInterface
 {
     protected ParserResolverInterface $resolver;
 
-    /**
-     * @param ParserResolverInterface $resolver
-     */
     public function __construct(ParserResolverInterface $resolver)
     {
         $this->resolver = $resolver;
     }
 
     /**
-     * @param string $color
      * @return array
      * @throws InvalidArgumentException
      */
@@ -38,7 +34,6 @@ class DelegatingParser implements ParserInterface
     }
 
     /**
-     * @param string $color
      * @return bool
      */
     public function supports(string $color) : bool

--- a/src/Parsers/HexParser.php
+++ b/src/Parsers/HexParser.php
@@ -10,7 +10,6 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class HexParser implements ParserInterface
 {
     /**
-     * @param string $color
      * @return array
      * @throws InvalidArgumentException
      */
@@ -41,7 +40,6 @@ class HexParser implements ParserInterface
     }
 
     /**
-     * @param string $color
      * @return bool
      */
     public function supports(string $color) : bool
@@ -52,7 +50,6 @@ class HexParser implements ParserInterface
     }
 
     /**
-     * @param string $color
      * @return bool
      */
     protected function containsOnlyHexCharacters(string $color) : bool
@@ -61,7 +58,6 @@ class HexParser implements ParserInterface
     }
 
     /**
-     * @param string $color
      * @return bool
      */
     protected function isValidLength(string $color) : bool
@@ -72,7 +68,6 @@ class HexParser implements ParserInterface
     }
 
     /**
-     * @param string $color
      * @return bool
      */
     protected function startsWithHash(string $color) : bool

--- a/src/Parsers/HexParser.php
+++ b/src/Parsers/HexParser.php
@@ -10,7 +10,6 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class HexParser implements ParserInterface
 {
     /**
-     * @return array
      * @throws InvalidArgumentException
      */
     public function parse(string $color) : array
@@ -39,9 +38,6 @@ class HexParser implements ParserInterface
         return array_combine($keys, $values);
     }
 
-    /**
-     * @return bool
-     */
     public function supports(string $color) : bool
     {
         return $this->startsWithHash($color)
@@ -49,17 +45,11 @@ class HexParser implements ParserInterface
             && $this->containsOnlyHexCharacters($color);
     }
 
-    /**
-     * @return bool
-     */
     protected function containsOnlyHexCharacters(string $color) : bool
     {
         return ! (bool) preg_match('/[^a-f0-9#]/i', $color);
     }
 
-    /**
-     * @return bool
-     */
     protected function isValidLength(string $color) : bool
     {
         $len = strlen($color);
@@ -67,9 +57,6 @@ class HexParser implements ParserInterface
         return 4 === $len || 5 === $len || 7 === $len || 9 === $len;
     }
 
-    /**
-     * @return bool
-     */
     protected function startsWithHash(string $color) : bool
     {
         return '#' === substr($color, 0, 1);

--- a/src/Parsers/HexParser.php
+++ b/src/Parsers/HexParser.php
@@ -28,9 +28,7 @@ class HexParser implements ParserInterface
         $len = strlen($color);
         $isShorthand = 3 === $len || 4 === $len;
 
-        $values = array_map(function ($value) use ($isShorthand) : int {
-            return hexdec($isShorthand ? str_repeat($value, 2) : $value);
-        }, str_split($color, $isShorthand ? 1 : 2));
+        $values = array_map(fn($value): int => hexdec($isShorthand ? str_repeat($value, 2) : $value), str_split($color, $isShorthand ? 1 : 2));
 
         $keys = ['red', 'green', 'blue'];
 

--- a/src/Parsers/HslParser.php
+++ b/src/Parsers/HslParser.php
@@ -7,9 +7,6 @@ namespace SSNepenthe\ColorUtils\Parsers;
  */
 class HslParser extends PatternParser
 {
-    /**
-     * @return string
-     */
     protected function getPattern() : string
     {
         return '/^hsl\(
@@ -19,9 +16,6 @@ class HslParser extends PatternParser
         \)$/ix';
     }
 
-    /**
-     * @return array
-     */
     protected function prepareExtractedData(array $data) : array
     {
         return array_map(fn($value): float => floatval(trim($value, '%')), $data);

--- a/src/Parsers/HslParser.php
+++ b/src/Parsers/HslParser.php
@@ -25,8 +25,6 @@ class HslParser extends PatternParser
      */
     protected function prepareExtractedData(array $data) : array
     {
-        return array_map(function ($value) : float {
-            return floatval(trim($value, '%'));
-        }, $data);
+        return array_map(fn($value): float => floatval(trim($value, '%')), $data);
     }
 }

--- a/src/Parsers/HslParser.php
+++ b/src/Parsers/HslParser.php
@@ -20,7 +20,6 @@ class HslParser extends PatternParser
     }
 
     /**
-     * @param array $data
      * @return array
      */
     protected function prepareExtractedData(array $data) : array

--- a/src/Parsers/HslaParser.php
+++ b/src/Parsers/HslaParser.php
@@ -7,9 +7,6 @@ namespace SSNepenthe\ColorUtils\Parsers;
  */
 class HslaParser extends HslParser
 {
-    /**
-     * @return string
-     */
     protected function getPattern() : string
     {
         return '/^hsla\(

--- a/src/Parsers/KeywordParser.php
+++ b/src/Parsers/KeywordParser.php
@@ -171,7 +171,7 @@ class KeywordParser implements ParserInterface
     /**
      * @param HexParser|null $parser
      */
-    public function __construct(HexParser $parser = null)
+    public function __construct(?HexParser $parser = null)
     {
         $this->parser = $parser ?: new HexParser;
     }

--- a/src/Parsers/KeywordParser.php
+++ b/src/Parsers/KeywordParser.php
@@ -165,16 +165,12 @@ class KeywordParser implements ParserInterface
 
     protected HexParser $parser;
 
-    /**
-     * @param HexParser|null $parser
-     */
     public function __construct(?HexParser $parser = null)
     {
         $this->parser = $parser ?: new HexParser;
     }
 
     /**
-     * @param string $color
      * @return array
      * @throws InvalidArgumentException
      */
@@ -192,7 +188,6 @@ class KeywordParser implements ParserInterface
     }
 
     /**
-     * @param string $color
      * @return bool
      */
     public function supports(string $color) : bool

--- a/src/Parsers/KeywordParser.php
+++ b/src/Parsers/KeywordParser.php
@@ -163,10 +163,7 @@ class KeywordParser implements ParserInterface
         'yellowgreen'          => '#9acd32',
     ];
 
-    /**
-     * @var HexParser
-     */
-    protected $parser;
+    protected HexParser $parser;
 
     /**
      * @param HexParser|null $parser

--- a/src/Parsers/KeywordParser.php
+++ b/src/Parsers/KeywordParser.php
@@ -171,7 +171,6 @@ class KeywordParser implements ParserInterface
     }
 
     /**
-     * @return array
      * @throws InvalidArgumentException
      */
     public function parse(string $color) : array
@@ -187,9 +186,6 @@ class KeywordParser implements ParserInterface
         return $this->parser->parse(self::MAP[strtolower($color)]);
     }
 
-    /**
-     * @return bool
-     */
     public function supports(string $color) : bool
     {
         return array_key_exists(strtolower($color), self::MAP);

--- a/src/Parsers/ParserInterface.php
+++ b/src/Parsers/ParserInterface.php
@@ -8,13 +8,11 @@ namespace SSNepenthe\ColorUtils\Parsers;
 interface ParserInterface
 {
     /**
-     * @param string $color
      * @return array
      */
     public function parse(string $color) : array;
 
     /**
-     * @param string $color
      * @return bool
      */
     public function supports(string $color) : bool;

--- a/src/Parsers/ParserInterface.php
+++ b/src/Parsers/ParserInterface.php
@@ -7,13 +7,7 @@ namespace SSNepenthe\ColorUtils\Parsers;
  */
 interface ParserInterface
 {
-    /**
-     * @return array
-     */
     public function parse(string $color) : array;
 
-    /**
-     * @return bool
-     */
     public function supports(string $color) : bool;
 }

--- a/src/Parsers/ParserResolver.php
+++ b/src/Parsers/ParserResolver.php
@@ -12,9 +12,6 @@ class ParserResolver implements ParserResolverInterface
      */
     protected $parsers = [];
 
-    /**
-     * @param array $parsers
-     */
     public function __construct(array $parsers)
     {
         foreach ($parsers as $parser) {
@@ -23,7 +20,6 @@ class ParserResolver implements ParserResolverInterface
     }
 
     /**
-     * @param string $color
      * @return ParserInterface|false
      */
     public function resolve(string $color)
@@ -38,7 +34,6 @@ class ParserResolver implements ParserResolverInterface
     }
 
     /**
-     * @param ParserInterface $parser
      * @return void
      */
     protected function addParser(ParserInterface $parser)

--- a/src/Parsers/ParserResolverFactory.php
+++ b/src/Parsers/ParserResolverFactory.php
@@ -7,9 +7,6 @@ namespace SSNepenthe\ColorUtils\Parsers;
  */
 class ParserResolverFactory
 {
-    /**
-     * @return ParserResolver
-     */
     public static function all() : ParserResolver
     {
         $hexParser = new HexParser;
@@ -24,9 +21,6 @@ class ParserResolverFactory
         ]);
     }
 
-    /**
-     * @return ParserResolver
-     */
     public static function rgb() : ParserResolver
     {
         $hexParser = new HexParser;
@@ -39,9 +33,6 @@ class ParserResolverFactory
         ]);
     }
 
-    /**
-     * @return ParserResolver
-     */
     public static function hsl() : ParserResolver
     {
         return new ParserResolver([

--- a/src/Parsers/ParserResolverInterface.php
+++ b/src/Parsers/ParserResolverInterface.php
@@ -8,7 +8,6 @@ namespace SSNepenthe\ColorUtils\Parsers;
 interface ParserResolverInterface
 {
     /**
-     * @param string $color
      * @return ParserInterface|false
      */
     public function resolve(string $color);

--- a/src/Parsers/PatternParser.php
+++ b/src/Parsers/PatternParser.php
@@ -10,7 +10,6 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 abstract class PatternParser implements ParserInterface
 {
     /**
-     * @param string $color
      * @return array
      * @throws InvalidArgumentException
      */
@@ -31,7 +30,6 @@ abstract class PatternParser implements ParserInterface
     }
 
     /**
-     * @param string $color
      * @return bool
      */
     public function supports(string $color) : bool
@@ -45,7 +43,6 @@ abstract class PatternParser implements ParserInterface
     abstract protected function getPattern() : string;
 
     /**
-     * @param array $data
      * @return array
      */
     abstract protected function prepareExtractedData(array $data) : array;

--- a/src/Parsers/PatternParser.php
+++ b/src/Parsers/PatternParser.php
@@ -25,9 +25,7 @@ abstract class PatternParser implements ParserInterface
         }
 
         // Filter out numerically indexed values.
-        $matches = array_filter($matches, function ($key) : bool {
-            return is_string($key);
-        }, ARRAY_FILTER_USE_KEY);
+        $matches = array_filter($matches, fn($key): bool => is_string($key), ARRAY_FILTER_USE_KEY);
 
         return $this->prepareExtractedData($matches);
     }

--- a/src/Parsers/PatternParser.php
+++ b/src/Parsers/PatternParser.php
@@ -10,7 +10,6 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 abstract class PatternParser implements ParserInterface
 {
     /**
-     * @return array
      * @throws InvalidArgumentException
      */
     public function parse(string $color) : array
@@ -29,21 +28,12 @@ abstract class PatternParser implements ParserInterface
         return $this->prepareExtractedData($matches);
     }
 
-    /**
-     * @return bool
-     */
     public function supports(string $color) : bool
     {
         return (bool) preg_match($this->getPattern(), $color);
     }
 
-    /**
-     * @return string
-     */
     abstract protected function getPattern() : string;
 
-    /**
-     * @return array
-     */
     abstract protected function prepareExtractedData(array $data) : array;
 }

--- a/src/Parsers/RgbParser.php
+++ b/src/Parsers/RgbParser.php
@@ -20,7 +20,6 @@ class RgbParser extends PatternParser
     }
 
     /**
-     * @param array $data
      * @return array
      */
     protected function prepareExtractedData(array $data) : array

--- a/src/Parsers/RgbParser.php
+++ b/src/Parsers/RgbParser.php
@@ -7,9 +7,6 @@ namespace SSNepenthe\ColorUtils\Parsers;
  */
 class RgbParser extends PatternParser
 {
-    /**
-     * @return string
-     */
     protected function getPattern() : string
     {
         return '/^rgb\(
@@ -19,9 +16,6 @@ class RgbParser extends PatternParser
         \)$/ix';
     }
 
-    /**
-     * @return array
-     */
     protected function prepareExtractedData(array $data) : array
     {
         return array_map(function (string $channel) : int {

--- a/src/Parsers/RgbaParser.php
+++ b/src/Parsers/RgbaParser.php
@@ -21,7 +21,6 @@ class RgbaParser extends RgbParser
     }
 
     /**
-     * @param array $data
      * @return array
      */
     protected function prepareExtractedData(array $data) : array

--- a/src/Parsers/RgbaParser.php
+++ b/src/Parsers/RgbaParser.php
@@ -7,9 +7,6 @@ namespace SSNepenthe\ColorUtils\Parsers;
  */
 class RgbaParser extends RgbParser
 {
-    /**
-     * @return string
-     */
     protected function getPattern() : string
     {
         return '/^rgba\(
@@ -20,9 +17,6 @@ class RgbaParser extends RgbParser
         \)$/ix';
     }
 
-    /**
-     * @return array
-     */
     protected function prepareExtractedData(array $data) : array
     {
         // Red, green and blue channels.

--- a/src/Transformers/AdjustColor.php
+++ b/src/Transformers/AdjustColor.php
@@ -42,7 +42,7 @@ class AdjustColor implements TransformerInterface
             }
         }
 
-        if (empty($this->adjustments)) {
+        if ($this->adjustments === []) {
             throw new InvalidArgumentException(sprintf(
                 'No valid adjustments provided in %s',
                 __METHOD__

--- a/src/Transformers/AdjustColor.php
+++ b/src/Transformers/AdjustColor.php
@@ -29,7 +29,6 @@ class AdjustColor implements TransformerInterface
     ];
 
     /**
-     * @param array $adjustments
      * @throws InvalidArgumentException
      */
     public function __construct(array $adjustments)
@@ -52,7 +51,6 @@ class AdjustColor implements TransformerInterface
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/AdjustColor.php
+++ b/src/Transformers/AdjustColor.php
@@ -35,9 +35,7 @@ class AdjustColor implements TransformerInterface
     public function __construct(array $adjustments)
     {
         // First filter out non-adjustments (0 or non-numeric adjustments).
-        $adjustments = array_filter($adjustments, function ($adjustment) : bool {
-            return $adjustment && is_numeric($adjustment);
-        });
+        $adjustments = array_filter($adjustments, fn($adjustment): bool => $adjustment && is_numeric($adjustment));
 
         foreach ($this->whitelist as $channel) {
             if (isset($adjustments[$channel])) {

--- a/src/Transformers/AdjustColor.php
+++ b/src/Transformers/AdjustColor.php
@@ -50,9 +50,6 @@ class AdjustColor implements TransformerInterface
         }
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         $channels = [];

--- a/src/Transformers/AdjustHue.php
+++ b/src/Transformers/AdjustHue.php
@@ -16,9 +16,6 @@ class AdjustHue implements TransformerInterface
         $this->transformer = new AdjustColor(['hue' => $amount]);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/AdjustHue.php
+++ b/src/Transformers/AdjustHue.php
@@ -9,10 +9,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class AdjustHue implements TransformerInterface
 {
-    /**
-     * @var AdjustColor
-     */
-    protected $transformer;
+    protected AdjustColor $transformer;
 
     /**
      * @param float $amount

--- a/src/Transformers/AdjustHue.php
+++ b/src/Transformers/AdjustHue.php
@@ -11,16 +11,12 @@ class AdjustHue implements TransformerInterface
 {
     protected AdjustColor $transformer;
 
-    /**
-     * @param float $amount
-     */
     public function __construct(float $amount)
     {
         $this->transformer = new AdjustColor(['hue' => $amount]);
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/ChangeColor.php
+++ b/src/Transformers/ChangeColor.php
@@ -35,9 +35,7 @@ class ChangeColor implements TransformerInterface
     public function __construct(array $adjustments)
     {
         // First filter out non-numeric adjustments.
-        $adjustments = array_filter($adjustments, function ($adjustment) : bool {
-            return is_numeric($adjustment);
-        });
+        $adjustments = array_filter($adjustments, fn($adjustment): bool => is_numeric($adjustment));
 
         foreach ($this->whitelist as $channel) {
             if (isset($adjustments[$channel])) {

--- a/src/Transformers/ChangeColor.php
+++ b/src/Transformers/ChangeColor.php
@@ -50,9 +50,6 @@ class ChangeColor implements TransformerInterface
         }
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $color->with($this->adjustments);

--- a/src/Transformers/ChangeColor.php
+++ b/src/Transformers/ChangeColor.php
@@ -42,7 +42,7 @@ class ChangeColor implements TransformerInterface
             }
         }
 
-        if (empty($this->adjustments)) {
+        if ($this->adjustments === []) {
             throw new InvalidArgumentException(sprintf(
                 'No valid adjustments provided in %s',
                 __METHOD__

--- a/src/Transformers/ChangeColor.php
+++ b/src/Transformers/ChangeColor.php
@@ -29,7 +29,6 @@ class ChangeColor implements TransformerInterface
     ];
 
     /**
-     * @param array $adjustments
      * @throws InvalidArgumentException
      */
     public function __construct(array $adjustments)
@@ -52,7 +51,6 @@ class ChangeColor implements TransformerInterface
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Complement.php
+++ b/src/Transformers/Complement.php
@@ -17,7 +17,6 @@ class Complement implements TransformerInterface
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Complement.php
+++ b/src/Transformers/Complement.php
@@ -16,9 +16,6 @@ class Complement implements TransformerInterface
         $this->transformer = new AdjustColor(['hue' => 180]);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/Complement.php
+++ b/src/Transformers/Complement.php
@@ -9,10 +9,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class Complement implements TransformerInterface
 {
-    /**
-     * @var AdjustColor
-     */
-    protected $transformer;
+    protected AdjustColor $transformer;
 
     public function __construct()
     {

--- a/src/Transformers/ConditionalTransformer.php
+++ b/src/Transformers/ConditionalTransformer.php
@@ -32,7 +32,7 @@ class ConditionalTransformer implements TransformerInterface
     public function __construct(
         callable $callback,
         TransformerInterface $truthyTransformer,
-        TransformerInterface $falsyTransformer = null
+        ?TransformerInterface $falsyTransformer = null
     ) {
         $this->callback = $callback;
         $this->truthyTransformer = $truthyTransformer;

--- a/src/Transformers/ConditionalTransformer.php
+++ b/src/Transformers/ConditionalTransformer.php
@@ -14,15 +14,9 @@ class ConditionalTransformer implements TransformerInterface
      */
     protected $callback;
 
-    /**
-     * @var TransformerInterface|null
-     */
-    protected $falsyTransformer = null;
+    protected ?TransformerInterface $falsyTransformer;
 
-    /**
-     * @var TransformerInterface
-     */
-    protected $truthyTransformer;
+    protected TransformerInterface $truthyTransformer;
 
     /**
      * @param callable $callback

--- a/src/Transformers/ConditionalTransformer.php
+++ b/src/Transformers/ConditionalTransformer.php
@@ -28,9 +28,6 @@ class ConditionalTransformer implements TransformerInterface
         $this->falsyTransformer = $falsyTransformer;
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         if (call_user_func($this->callback, $color)) {

--- a/src/Transformers/ConditionalTransformer.php
+++ b/src/Transformers/ConditionalTransformer.php
@@ -18,11 +18,6 @@ class ConditionalTransformer implements TransformerInterface
 
     protected TransformerInterface $truthyTransformer;
 
-    /**
-     * @param callable $callback
-     * @param TransformerInterface $truthyTransformer
-     * @param TransformerInterface|null $falsyTransformer
-     */
     public function __construct(
         callable $callback,
         TransformerInterface $truthyTransformer,
@@ -34,7 +29,6 @@ class ConditionalTransformer implements TransformerInterface
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Darken.php
+++ b/src/Transformers/Darken.php
@@ -16,9 +16,6 @@ class Darken implements TransformerInterface
         $this->transformer = new AdjustColor(['lightness' => -1 * $amount]);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/Darken.php
+++ b/src/Transformers/Darken.php
@@ -9,10 +9,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class Darken implements TransformerInterface
 {
-    /**
-     * @var AdjustColor
-     */
-    protected $transformer;
+    protected AdjustColor $transformer;
 
     /**
      * @param float $amount

--- a/src/Transformers/Darken.php
+++ b/src/Transformers/Darken.php
@@ -11,16 +11,12 @@ class Darken implements TransformerInterface
 {
     protected AdjustColor $transformer;
 
-    /**
-     * @param float $amount
-     */
     public function __construct(float $amount)
     {
         $this->transformer = new AdjustColor(['lightness' => -1 * $amount]);
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Desaturate.php
+++ b/src/Transformers/Desaturate.php
@@ -9,10 +9,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class Desaturate implements TransformerInterface
 {
-    /**
-     * @var AdjustColor
-     */
-    protected $transformer;
+    protected AdjustColor $transformer;
 
     /**
      * @param float $amount

--- a/src/Transformers/Desaturate.php
+++ b/src/Transformers/Desaturate.php
@@ -11,16 +11,12 @@ class Desaturate implements TransformerInterface
 {
     protected AdjustColor $transformer;
 
-    /**
-     * @param float $amount
-     */
     public function __construct(float $amount)
     {
         $this->transformer = new AdjustColor(['saturation' => -1 * $amount]);
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Desaturate.php
+++ b/src/Transformers/Desaturate.php
@@ -16,9 +16,6 @@ class Desaturate implements TransformerInterface
         $this->transformer = new AdjustColor(['saturation' => -1 * $amount]);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/GrayScale.php
+++ b/src/Transformers/GrayScale.php
@@ -16,9 +16,6 @@ class GrayScale implements TransformerInterface
         $this->transformer = new ChangeColor(['saturation' => 0]);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/GrayScale.php
+++ b/src/Transformers/GrayScale.php
@@ -9,10 +9,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class GrayScale implements TransformerInterface
 {
-    /**
-     * @var ChangeColor
-     */
-    protected $transformer;
+    protected ChangeColor $transformer;
 
     public function __construct()
     {

--- a/src/Transformers/GrayScale.php
+++ b/src/Transformers/GrayScale.php
@@ -17,7 +17,6 @@ class GrayScale implements TransformerInterface
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Invert.php
+++ b/src/Transformers/Invert.php
@@ -10,7 +10,6 @@ use SSNepenthe\ColorUtils\Colors\Color;
 class Invert implements TransformerInterface
 {
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Invert.php
+++ b/src/Transformers/Invert.php
@@ -9,9 +9,6 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class Invert implements TransformerInterface
 {
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $color->with([

--- a/src/Transformers/Lighten.php
+++ b/src/Transformers/Lighten.php
@@ -11,16 +11,12 @@ class Lighten implements TransformerInterface
 {
     protected AdjustColor $transformer;
 
-    /**
-     * @param float $amount
-     */
     public function __construct(float $amount)
     {
         $this->transformer = new AdjustColor(['lightness' => $amount]);
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Lighten.php
+++ b/src/Transformers/Lighten.php
@@ -9,10 +9,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class Lighten implements TransformerInterface
 {
-    /**
-     * @var AdjustColor
-     */
-    protected $transformer;
+    protected AdjustColor $transformer;
 
     /**
      * @param float $amount

--- a/src/Transformers/Lighten.php
+++ b/src/Transformers/Lighten.php
@@ -16,9 +16,6 @@ class Lighten implements TransformerInterface
         $this->transformer = new AdjustColor(['lightness' => $amount]);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/Mix.php
+++ b/src/Transformers/Mix.php
@@ -10,10 +10,7 @@ use function SSNepenthe\ColorUtils\restrict;
  */
 class Mix implements TransformerInterface
 {
-    /**
-     * @var Color
-     */
-    protected $color;
+    protected Color $color;
 
     /**
      * @var int

--- a/src/Transformers/Mix.php
+++ b/src/Transformers/Mix.php
@@ -17,10 +17,6 @@ class Mix implements TransformerInterface
      */
     protected $weight;
 
-    /**
-     * @param Color $color
-     * @param int $weight
-     */
     public function __construct(Color $color, int $weight = 50)
     {
         $this->color = $color;
@@ -28,7 +24,6 @@ class Mix implements TransformerInterface
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Mix.php
+++ b/src/Transformers/Mix.php
@@ -23,9 +23,6 @@ class Mix implements TransformerInterface
         $this->weight = restrict($weight, 0, 100);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         $percentage = $this->weight / 100;

--- a/src/Transformers/Opacify.php
+++ b/src/Transformers/Opacify.php
@@ -16,9 +16,6 @@ class Opacify implements TransformerInterface
         $this->transformer = new AdjustColor(['alpha' => $amount]);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/Opacify.php
+++ b/src/Transformers/Opacify.php
@@ -11,16 +11,12 @@ class Opacify implements TransformerInterface
 {
     protected AdjustColor $transformer;
 
-    /**
-     * @param float $amount
-     */
     public function __construct(float $amount)
     {
         $this->transformer = new AdjustColor(['alpha' => $amount]);
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Opacify.php
+++ b/src/Transformers/Opacify.php
@@ -9,10 +9,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class Opacify implements TransformerInterface
 {
-    /**
-     * @var AdjustColor
-     */
-    protected $transformer;
+    protected AdjustColor $transformer;
 
     /**
      * @param float $amount

--- a/src/Transformers/Saturate.php
+++ b/src/Transformers/Saturate.php
@@ -9,10 +9,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class Saturate implements TransformerInterface
 {
-    /**
-     * @var AdjustColor
-     */
-    protected $transformer;
+    protected AdjustColor $transformer;
 
     /**
      * @param float $amount

--- a/src/Transformers/Saturate.php
+++ b/src/Transformers/Saturate.php
@@ -11,16 +11,12 @@ class Saturate implements TransformerInterface
 {
     protected AdjustColor $transformer;
 
-    /**
-     * @param float $amount
-     */
     public function __construct(float $amount)
     {
         $this->transformer = new AdjustColor(['saturation' => $amount]);
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Saturate.php
+++ b/src/Transformers/Saturate.php
@@ -16,9 +16,6 @@ class Saturate implements TransformerInterface
         $this->transformer = new AdjustColor(['saturation' => $amount]);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/ScaleColor.php
+++ b/src/Transformers/ScaleColor.php
@@ -38,9 +38,7 @@ class ScaleColor implements TransformerInterface
     public function __construct(array $adjustments)
     {
         // First filter out non-numeric adjustments.
-        $adjustments = array_filter($adjustments, function ($adjustment) : bool {
-            return is_numeric($adjustment);
-        });
+        $adjustments = array_filter($adjustments, fn($adjustment): bool => is_numeric($adjustment));
 
         foreach ($this->whitelist as $channel => $_) {
             if (isset($adjustments[$channel])) {

--- a/src/Transformers/ScaleColor.php
+++ b/src/Transformers/ScaleColor.php
@@ -57,9 +57,6 @@ class ScaleColor implements TransformerInterface
         }
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         $channels = [];

--- a/src/Transformers/ScaleColor.php
+++ b/src/Transformers/ScaleColor.php
@@ -32,7 +32,6 @@ class ScaleColor implements TransformerInterface
     ];
 
     /**
-     * @param array $adjustments
      * @throws InvalidArgumentException
      */
     public function __construct(array $adjustments)
@@ -59,7 +58,6 @@ class ScaleColor implements TransformerInterface
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/ScaleColor.php
+++ b/src/Transformers/ScaleColor.php
@@ -49,7 +49,7 @@ class ScaleColor implements TransformerInterface
             }
         }
 
-        if (empty($this->adjustments)) {
+        if ($this->adjustments === []) {
             throw new InvalidArgumentException(sprintf(
                 'No valid adjustments provided in %s',
                 __METHOD__

--- a/src/Transformers/Shade.php
+++ b/src/Transformers/Shade.php
@@ -17,9 +17,6 @@ class Shade implements TransformerInterface
         $this->transformer = new Mix(new Color(new Rgb(0, 0, 0)), $weight);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/Shade.php
+++ b/src/Transformers/Shade.php
@@ -10,10 +10,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class Shade implements TransformerInterface
 {
-    /**
-     * @var Mix
-     */
-    protected $transformer;
+    protected Mix $transformer;
 
     /**
      * @param int $weight

--- a/src/Transformers/Shade.php
+++ b/src/Transformers/Shade.php
@@ -12,16 +12,12 @@ class Shade implements TransformerInterface
 {
     protected Mix $transformer;
 
-    /**
-     * @param int $weight
-     */
     public function __construct(int $weight = 50)
     {
         $this->transformer = new Mix(new Color(new Rgb(0, 0, 0)), $weight);
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Tint.php
+++ b/src/Transformers/Tint.php
@@ -17,9 +17,6 @@ class Tint implements TransformerInterface
         $this->transformer = new Mix(new Color(new Rgb(255, 255, 255)), $weight);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/Tint.php
+++ b/src/Transformers/Tint.php
@@ -12,16 +12,12 @@ class Tint implements TransformerInterface
 {
     protected Mix $transformer;
 
-    /**
-     * @param int $weight
-     */
     public function __construct(int $weight = 50)
     {
         $this->transformer = new Mix(new Color(new Rgb(255, 255, 255)), $weight);
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Tint.php
+++ b/src/Transformers/Tint.php
@@ -10,10 +10,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class Tint implements TransformerInterface
 {
-    /**
-     * @var Mix
-     */
-    protected $transformer;
+    protected Mix $transformer;
 
     /**
      * @param int $weight

--- a/src/Transformers/TransformerInterface.php
+++ b/src/Transformers/TransformerInterface.php
@@ -10,7 +10,6 @@ use SSNepenthe\ColorUtils\Colors\Color;
 interface TransformerInterface
 {
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color;

--- a/src/Transformers/TransformerInterface.php
+++ b/src/Transformers/TransformerInterface.php
@@ -9,8 +9,5 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 interface TransformerInterface
 {
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color;
 }

--- a/src/Transformers/TransformerPipeline.php
+++ b/src/Transformers/TransformerPipeline.php
@@ -14,9 +14,6 @@ class TransformerPipeline implements TransformerInterface
      */
     protected $transformers = [];
 
-    /**
-     * @param array $transformers
-     */
     public function __construct(array $transformers = [])
     {
         foreach ($transformers as $transformer) {
@@ -25,7 +22,6 @@ class TransformerPipeline implements TransformerInterface
     }
 
     /**
-     * @param TransformerInterface $transformer
      * @return void
      */
     public function add(TransformerInterface $transformer): void
@@ -34,7 +30,6 @@ class TransformerPipeline implements TransformerInterface
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/TransformerPipeline.php
+++ b/src/Transformers/TransformerPipeline.php
@@ -28,7 +28,7 @@ class TransformerPipeline implements TransformerInterface
      * @param TransformerInterface $transformer
      * @return void
      */
-    public function add(TransformerInterface $transformer)
+    public function add(TransformerInterface $transformer): void
     {
         $this->transformers[] = $transformer;
     }

--- a/src/Transformers/TransformerPipeline.php
+++ b/src/Transformers/TransformerPipeline.php
@@ -21,17 +21,11 @@ class TransformerPipeline implements TransformerInterface
         }
     }
 
-    /**
-     * @return void
-     */
     public function add(TransformerInterface $transformer): void
     {
         $this->transformers[] = $transformer;
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         foreach ($this->transformers as $transformer) {

--- a/src/Transformers/Transparentize.php
+++ b/src/Transformers/Transparentize.php
@@ -16,9 +16,6 @@ class Transparentize implements TransformerInterface
         $this->transformer = new AdjustColor(['alpha' => -1 * $amount]);
     }
 
-    /**
-     * @return Color
-     */
     public function transform(Color $color) : Color
     {
         return $this->transformer->transform($color);

--- a/src/Transformers/Transparentize.php
+++ b/src/Transformers/Transparentize.php
@@ -11,16 +11,12 @@ class Transparentize implements TransformerInterface
 {
     protected AdjustColor $transformer;
 
-    /**
-     * @param float $amount
-     */
     public function __construct(float $amount)
     {
         $this->transformer = new AdjustColor(['alpha' => -1 * $amount]);
     }
 
     /**
-     * @param Color $color
      * @return Color
      */
     public function transform(Color $color) : Color

--- a/src/Transformers/Transparentize.php
+++ b/src/Transformers/Transparentize.php
@@ -9,10 +9,7 @@ use SSNepenthe\ColorUtils\Colors\Color;
  */
 class Transparentize implements TransformerInterface
 {
-    /**
-     * @var AdjustColor
-     */
-    protected $transformer;
+    protected AdjustColor $transformer;
 
     /**
      * @param float $amount

--- a/tests/Colors/ColorFactoryTest.php
+++ b/tests/Colors/ColorFactoryTest.php
@@ -9,7 +9,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class ColorFactoryTest extends TestCase
 {
     /** @test */
-    function it_gets_the_values_right_no_matter_how_it_is_created()
+    function it_gets_the_values_right_no_matter_how_it_is_created(): void
     {
         $colors = [
             ColorFactory::fromString('hsl(348, 100%, 50%)'),
@@ -31,7 +31,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_colors_from_array()
+    function it_can_create_colors_from_array(): void
     {
         $colors = [
             ColorFactory::fromArray(['red' => 255, 'green' => 0, 'blue' => 51]),
@@ -53,7 +53,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_color_from_hsl_values()
+    function it_can_create_color_from_hsl_values(): void
     {
         $colors = [
             ColorFactory::fromHsl(348, 100, 50),
@@ -67,7 +67,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_color_from_rgb_values()
+    function it_can_create_color_from_rgb_values(): void
     {
         $colors = [
             ColorFactory::fromRgb(255, 0, 51),
@@ -81,7 +81,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_colors_from_strings()
+    function it_can_create_colors_from_strings(): void
     {
         $colors = [
             ColorFactory::fromString('#ff0000'),
@@ -100,7 +100,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_colors_from_unknown_args()
+    function it_can_create_colors_from_unknown_args(): void
     {
         $colors = [
             ColorFactory::fromUnknown('#fff'),
@@ -114,7 +114,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_colors_from_single_unknown_arg()
+    function it_can_create_colors_from_single_unknown_arg(): void
     {
         $c1 = new Color(new Rgb(255, 255, 255));
         $c2 = ColorFactory::fromUnknownOneArg($c1);
@@ -135,7 +135,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_colors_from_three_unknown_args()
+    function it_can_create_colors_from_three_unknown_args(): void
     {
         $this->assertEquals(
             'rgb(255, 255, 255)',
@@ -155,7 +155,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_colors_from_four_unknown_args()
+    function it_can_create_colors_from_four_unknown_args(): void
     {
         $this->assertEquals(
             'rgba(255, 255, 255, 0.7)',
@@ -175,7 +175,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_cant_create_a_color_without_a_complete_color_array()
+    function it_cant_create_a_color_without_a_complete_color_array(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -183,7 +183,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_cant_create_an_unknown_color_with_bad_args()
+    function it_cant_create_an_unknown_color_with_bad_args(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -191,7 +191,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_cant_create_a_color_from_four_args_if_out_of_bounds()
+    function it_cant_create_a_color_from_four_args_if_out_of_bounds(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -199,7 +199,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_cant_create_a_color_from_one_arg_if_wrong_type()
+    function it_cant_create_a_color_from_one_arg_if_wrong_type(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -207,7 +207,7 @@ class ColorFactoryTest extends TestCase
     }
 
     /** @test */
-    function it_cant_create_a_color_from_three_args_if_out_of_bounds()
+    function it_cant_create_a_color_from_three_args_if_out_of_bounds(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Colors/ColorTest.php
+++ b/tests/Colors/ColorTest.php
@@ -12,7 +12,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class ColorTest extends TestCase
 {
     /** @test */
-    function it_is_instantiable()
+    function it_is_instantiable(): void
     {
         $color = new Color(new Rgb(255, 0, 51));
 
@@ -20,7 +20,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_proxies_all_rgb_methods()
+    function it_correctly_proxies_all_rgb_methods(): void
     {
         $color = new Color(new Rgb(255, 0, 51));
 
@@ -60,7 +60,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_proxies_all_hsl_methods()
+    function it_correctly_proxies_all_hsl_methods(): void
     {
         $color = new Color(new Hsl(348, 100, 50));
 
@@ -86,7 +86,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_override_base_color_on_instantiation()
+    function it_can_override_base_color_on_instantiation(): void
     {
         $rgb = new Color(new Rgb(255, 0, 51));
         $rgba = new Color(new Rgba(255, 0, 51, 0.7));
@@ -100,7 +100,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_calculate_brightness_difference_with_a_color()
+    function it_can_calculate_brightness_difference_with_a_color(): void
     {
         $color1 = new Color(new Rgb(255, 0, 51));
         $color2 = new Color(new Rgb(51, 0, 255));
@@ -118,7 +118,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_calculate_color_difference_with_a_color()
+    function it_can_calculate_color_difference_with_a_color(): void
     {
         $color1 = new Color(new Rgb(255, 0, 51));
         $color2 = new Color(new Rgb(51, 0, 255));
@@ -128,7 +128,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_calculate_contrast_ratio_with_a_color()
+    function it_can_calculate_contrast_ratio_with_a_color(): void
     {
         $color1 = new Color(new Rgb(255, 0, 51));
         $color2 = new Color(new Rgb(51, 0, 255));
@@ -138,7 +138,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_retrieve_individual_representations()
+    function it_can_retrieve_individual_representations(): void
     {
         $color = new Color(new Rgb(255, 0, 51));
 
@@ -147,7 +147,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_a_modified_versions_of_itself()
+    function it_can_create_a_modified_versions_of_itself(): void
     {
         $white = (new Color(new Rgb(255, 255, 0)))->with(['blue' => 255]);
         $blue = (new Color(new Hsl(348, 100, 50)))->with(['hue' => 240]);
@@ -169,7 +169,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_creates_a_new_color_with_the_same_type_as_original()
+    function it_creates_a_new_color_with_the_same_type_as_original(): void
     {
         $hsl = new Color(new Hsl(60, 100, 50));
         $rgb = new Color(new Rgb(255, 255, 0));
@@ -179,7 +179,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_throws_exception_for_non_existent_methods()
+    function it_throws_exception_for_non_existent_methods(): void
     {
         $this->expectException(BadMethodCallException::class);
 
@@ -187,7 +187,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_cant_modify_hsl_and_rgb_in_same_operation()
+    function it_cant_modify_hsl_and_rgb_in_same_operation(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -195,7 +195,7 @@ class ColorTest extends TestCase
     }
 
     /** @test */
-    function it_cant_create_a_new_color_without_any_changes()
+    function it_cant_create_a_new_color_without_any_changes(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Colors/HslTest.php
+++ b/tests/Colors/HslTest.php
@@ -10,7 +10,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class HslTest extends TestCase
 {
     /** @test */
-    function it_is_instantiable()
+    function it_is_instantiable(): void
     {
         $hsl = new Hsl(348, 100, 50);
 
@@ -19,7 +19,7 @@ class HslTest extends TestCase
     }
 
     /** @test */
-    function it_rotates_hue_into_a_0_to_360_range()
+    function it_rotates_hue_into_a_0_to_360_range(): void
     {
         $tests = [
             1   => new Hsl(361, 50, 50),
@@ -34,7 +34,7 @@ class HslTest extends TestCase
     }
 
     /** @test */
-    function it_forces_a_0_to_100_range_for_saturation_and_lightness()
+    function it_forces_a_0_to_100_range_for_saturation_and_lightness(): void
     {
         $hsl = new Hsl(0, -50, -100);
         $hsl2 = new Hsl(0, 150, 200);
@@ -47,7 +47,7 @@ class HslTest extends TestCase
     }
 
     /** @test */
-    function it_can_be_cast_to_a_string()
+    function it_can_be_cast_to_a_string(): void
     {
         $hsl = new Hsl(348, 100, 50);
 
@@ -56,7 +56,7 @@ class HslTest extends TestCase
     }
 
     /** @test */
-    function channel_getters_give_correct_value()
+    function channel_getters_give_correct_value(): void
     {
         $hsl = new Hsl(348, 100, 50);
 
@@ -68,21 +68,21 @@ class HslTest extends TestCase
     }
 
     /** @test */
-    function it_can_tell_lightness()
+    function it_can_tell_lightness(): void
     {
         $this->assertTrue((new Hsl(38, 100, 51))->isLight());
         $this->assertFalse((new Hsl(274, 100, 25))->isLight());
     }
 
     /** @test */
-    function it_can_tell_lightness_with_custom_threshold()
+    function it_can_tell_lightness_with_custom_threshold(): void
     {
         $this->assertTrue((new Hsl(60, 100, 50))->isLight(35));
         $this->assertFalse((new Hsl(120, 100, 25))->isLight(35));
     }
 
     /** @test */
-    function it_correctly_produces_hsl_array()
+    function it_correctly_produces_hsl_array(): void
     {
         $this->assertEquals(
             ['hue' => 348, 'saturation' => 100, 'lightness' => 50],
@@ -91,7 +91,7 @@ class HslTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_produces_color_instance()
+    function it_correctly_produces_color_instance(): void
     {
         $this->assertInstanceOf(
             Color::class,
@@ -100,7 +100,7 @@ class HslTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_a_modified_version_of_itself()
+    function it_can_create_a_modified_version_of_itself(): void
     {
         $hsl = new Hsl(348, 100, 50);
         $hsl2 = $hsl->with(['hue' => 0]);
@@ -111,7 +111,7 @@ class HslTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_a_version_of_itself_with_transparency()
+    function it_can_create_a_version_of_itself_with_transparency(): void
     {
         $hsl = new Hsl(348, 100, 50);
         $hsla = $hsl->with(['hue' => 0, 'saturation' => 0, 'alpha' => 0.7]);
@@ -121,7 +121,7 @@ class HslTest extends TestCase
     }
 
     /** @test */
-    function it_cant_be_instantiated_with_non_numeric_values()
+    function it_cant_be_instantiated_with_non_numeric_values(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -129,7 +129,7 @@ class HslTest extends TestCase
     }
 
     /** @test */
-    function it_cant_create_a_new_instance_without_valid_attrs()
+    function it_cant_create_a_new_instance_without_valid_attrs(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Colors/HslaTest.php
+++ b/tests/Colors/HslaTest.php
@@ -9,7 +9,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class HslaTest extends TestCase
 {
     /** @test */
-    function it_is_instantiable()
+    function it_is_instantiable(): void
     {
         $hsla = new Hsla(348, 100, 50, 0.7);
 
@@ -18,7 +18,7 @@ class HslaTest extends TestCase
     }
 
     /** @test */
-    function it_forces_a_0_to_1_range_for_alpha()
+    function it_forces_a_0_to_1_range_for_alpha(): void
     {
         $hsla = new Hsla(0, 0, 0, -0.1);
         $hsla2 = new Hsla(0, 0, 0, 1.1);
@@ -28,7 +28,7 @@ class HslaTest extends TestCase
     }
 
     /** @test */
-    function it_can_be_cast_to_a_string()
+    function it_can_be_cast_to_a_string(): void
     {
         $hsla = new Hsla(348, 100, 50, 0.7);
 
@@ -37,7 +37,7 @@ class HslaTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_formats_alpha_channel_in_string_conversion()
+    function it_correctly_formats_alpha_channel_in_string_conversion(): void
     {
         /*
 
@@ -61,7 +61,7 @@ class HslaTest extends TestCase
     }
 
     /** @test */
-    function channel_getters_give_correct_value()
+    function channel_getters_give_correct_value(): void
     {
         $hsla = new Hsla(348, 100, 50, 0.7);
 
@@ -70,7 +70,7 @@ class HslaTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_produces_hsl_array()
+    function it_correctly_produces_hsl_array(): void
     {
         $hsla = new Hsla(348, 100, 50, 0.7);
         $hsla2 = new Hsla(348, 100, 50, 1);
@@ -86,7 +86,7 @@ class HslaTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_produces_color_instance()
+    function it_correctly_produces_color_instance(): void
     {
         $this->assertInstanceOf(
             Color::class,
@@ -95,7 +95,7 @@ class HslaTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_a_modified_version_of_itself()
+    function it_can_create_a_modified_version_of_itself(): void
     {
         $hsla = new Hsla(348, 100, 50, 0.7);
         $hsla2 = $hsla->with(['hue' => 0]);
@@ -106,7 +106,7 @@ class HslaTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_a_version_of_itself_without_transparency()
+    function it_can_create_a_version_of_itself_without_transparency(): void
     {
         $hsla = new Hsla(348, 100, 50, 0.7);
         $hsl = $hsla->with(['hue' => 0, 'saturation' => 0, 'alpha' => 1]);
@@ -117,7 +117,7 @@ class HslaTest extends TestCase
     }
 
     /** @test */
-    function it_cant_be_instantiated_with_non_numeric_values()
+    function it_cant_be_instantiated_with_non_numeric_values(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Colors/RgbTest.php
+++ b/tests/Colors/RgbTest.php
@@ -10,7 +10,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class RgbTest extends TestCase
 {
     /** @test */
-    function it_is_instantiable()
+    function it_is_instantiable(): void
     {
         $rgb = new Rgb(255, 0, 51);
 
@@ -19,14 +19,14 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function it_forces_a_0_to_255_range_for_colors()
+    function it_forces_a_0_to_255_range_for_colors(): void
     {
         $this->assertEquals('rgb(0, 0, 0)', new Rgb(-1, -50, -100));
         $this->assertEquals('rgb(255, 255, 255)', new Rgb(256, 300, 350));
     }
 
     /** @test */
-    function it_can_be_cast_to_a_string()
+    function it_can_be_cast_to_a_string(): void
     {
         $rgb = new Rgb(255, 0, 51);
 
@@ -35,13 +35,13 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function it_can_calculate_brightness()
+    function it_can_calculate_brightness(): void
     {
         $this->assertEquals(82.059, (new Rgb(255, 0, 51))->calculateBrightness());
     }
 
     /** @test */
-    function it_can_calculate_perceived_brightness()
+    function it_can_calculate_perceived_brightness(): void
     {
         $map = [
             '0.0'       => new Rgb(0, 0, 0), // Black.
@@ -64,7 +64,7 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function it_can_calculate_relative_luminance()
+    function it_can_calculate_relative_luminance(): void
     {
         $this->assertEquals(
             0.21499,
@@ -73,7 +73,7 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function channel_getters_give_correct_value()
+    function channel_getters_give_correct_value(): void
     {
         $rgb = new Rgb(255, 0, 51);
 
@@ -91,33 +91,33 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function it_can_tell_brightness()
+    function it_can_tell_brightness(): void
     {
         $this->assertFalse((new Rgb(255, 0, 51))->isBright());
     }
 
     /** @test */
-    function it_can_tell_brightness_with_custom_threshold()
+    function it_can_tell_brightness_with_custom_threshold(): void
     {
         $this->assertTrue((new Rgb(255, 0, 51))->isBright(80));
     }
 
     /** @test */
-    function it_can_tell_perceived_brightness()
+    function it_can_tell_perceived_brightness(): void
     {
         $this->assertTrue((new Rgb(255, 165, 0))->looksBright()); // Orange.
         $this->assertFalse((new Rgb(0, 0, 255))->looksBright()); // Blue.
     }
 
     /** @test */
-    function it_can_tell_perceived_brightness_with_custom_threshold()
+    function it_can_tell_perceived_brightness_with_custom_threshold(): void
     {
         $this->assertFalse((new Rgb(255, 255, 0))->looksBright(245)); // Yellow.
         $this->assertTrue((new Rgb(0, 0, 255))->looksBright(80)); // Blue.
     }
 
     /** @test */
-    function it_correctly_produces_rgb_array()
+    function it_correctly_produces_rgb_array(): void
     {
         $this->assertEquals(
             ['red' => 255, 'green' => 0, 'blue' => 51],
@@ -126,13 +126,13 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_produces_color_instance()
+    function it_correctly_produces_color_instance(): void
     {
         $this->assertInstanceOf(Color::class, (new Rgb(255, 0, 51))->toColor());
     }
 
     /** @test */
-    function it_correctly_produces_hex_array()
+    function it_correctly_produces_hex_array(): void
     {
         $this->assertEquals(
             ['red' => 'ff', 'green' => '00', 'blue' => '33'],
@@ -141,13 +141,13 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_produces_hex_string()
+    function it_correctly_produces_hex_string(): void
     {
         $this->assertEquals('#ff0033', (new Rgb(255, 0, 51))->toHexString());
     }
 
     /** @test */
-    function it_can_create_a_modified_version_of_itself()
+    function it_can_create_a_modified_version_of_itself(): void
     {
         $rgb = new Rgb(255, 0, 51);
 
@@ -156,7 +156,7 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_a_version_of_itself_with_transparency()
+    function it_can_create_a_version_of_itself_with_transparency(): void
     {
         $rgba = (new Rgb(255, 0, 51))->with([
             'red' => 0, 'blue' => 0, 'alpha' => 0.7]
@@ -167,7 +167,7 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function it_cant_be_instantiated_with_non_numeric_values()
+    function it_cant_be_instantiated_with_non_numeric_values(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -175,7 +175,7 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function it_cant_create_a_new_instance_without_valid_attrs()
+    function it_cant_create_a_new_instance_without_valid_attrs(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -183,7 +183,7 @@ class RgbTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_pads_hex_bytes()
+    function it_correctly_pads_hex_bytes(): void
     {
         $this->assertEquals(
             ['red' => '0a', 'green' => '0b', 'blue' => '0c'],

--- a/tests/Colors/RgbaTest.php
+++ b/tests/Colors/RgbaTest.php
@@ -9,7 +9,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class RgbaTest extends TestCase
 {
     /** @test */
-    function it_is_instantiable()
+    function it_is_instantiable(): void
     {
         $rgba = new Rgba(255, 0, 51, 0.7);
 
@@ -18,7 +18,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function it_forces_a_0_to_1_range_for_alpha()
+    function it_forces_a_0_to_1_range_for_alpha(): void
     {
         $rgba = new Rgba(0, 0, 0, -0.1);
         $rgba2 = new Rgba(0, 0, 0, 1.1);
@@ -28,7 +28,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function it_can_be_cast_to_a_string()
+    function it_can_be_cast_to_a_string(): void
     {
         $rgba = new Rgba(255, 0, 51, 0.7);
 
@@ -37,7 +37,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_formats_alpha_channel_in_string_conversion()
+    function it_correctly_formats_alpha_channel_in_string_conversion(): void
     {
         /*
 
@@ -61,7 +61,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function channel_getters_give_correct_value()
+    function channel_getters_give_correct_value(): void
     {
         $rgba = new Rgba(255, 0, 51, 0.7);
 
@@ -70,7 +70,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_produces_rgb_array()
+    function it_correctly_produces_rgb_array(): void
     {
         $rgba = new Rgba(255, 0, 51, 0.7);
         $rgba2 = new Rgba(255, 0, 51, 1);
@@ -86,7 +86,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_produces_color_instance()
+    function it_correctly_produces_color_instance(): void
     {
         $this->assertInstanceOf(
             Color::class,
@@ -95,7 +95,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_produces_hex_array()
+    function it_correctly_produces_hex_array(): void
     {
         $one = new Rgba(255, 0, 51, 1.0);
         $two = new Rgba(255, 0, 51, 0.7);
@@ -111,7 +111,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_produces_hex_string()
+    function it_correctly_produces_hex_string(): void
     {
         $one = new Rgba(255, 0, 51, 1.0);
         $two = new Rgba(255, 0, 51, 0.7);
@@ -125,7 +125,7 @@ class RgbaTest extends TestCase
      *
      * @test
      */
-    function it_accounts_for_alpha_value_when_determining_color_name()
+    function it_accounts_for_alpha_value_when_determining_color_name(): void
     {
         $purple = new Rgba(128, 0, 128, 1.0);
         $notPurple = new Rgba(128, 0, 128, 0.7);
@@ -135,7 +135,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_a_modified_version_of_itself()
+    function it_can_create_a_modified_version_of_itself(): void
     {
         $rgba = new Rgba(255, 0, 51, 0.7);
         $rgba2 = $rgba->with(['blue' => 0]);
@@ -146,7 +146,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_a_version_of_itself_without_transparency()
+    function it_can_create_a_version_of_itself_without_transparency(): void
     {
         $rgba = new Rgba(255, 0, 51, 0.7);
         $rgb = $rgba->with(['red' => 0, 'blue' => 0, 'alpha' => 1]);
@@ -157,7 +157,7 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
-    function it_cant_be_instantiated_with_non_numeric_alpha()
+    function it_cant_be_instantiated_with_non_numeric_alpha(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/ColorsTest.php
+++ b/tests/ColorsTest.php
@@ -15,7 +15,7 @@ class ColorsTest extends TestCase
 {
     protected $c;
 
-    function set_up()
+    function set_up(): void
     {
         $this->c = new C(new R(255, 0, 51, 0.7));
     }

--- a/tests/ColorsTest.php
+++ b/tests/ColorsTest.php
@@ -21,55 +21,55 @@ class ColorsTest extends TestCase
     }
 
     /** @test */
-    function alpha()
+    function alpha(): void
     {
         $this->assertEquals(0.7, alpha($this->c));
     }
 
     /** @test */
-    function blue()
+    function blue(): void
     {
         $this->assertEquals(51, blue($this->c));
     }
 
     /** @test */
-    function brightness()
+    function brightness(): void
     {
         $this->assertEquals(82.059, brightness($this->c));
     }
 
     /** @test */
-    function brightness_difference()
+    function brightness_difference(): void
     {
         $this->assertEquals(143.871, brightness_difference($this->c, color('#ff0')));
     }
 
     /** @test */
-    function color()
+    function color(): void
     {
         $this->assertInstanceOf(C::class, color(255, 0, 51, 0.7));
     }
 
     /** @test */
-    function color_difference()
+    function color_difference(): void
     {
         $this->assertEquals(306, color_difference($this->c, color('#ff0')));
     }
 
     /** @test */
-    function contrast_ratio()
+    function contrast_ratio(): void
     {
         $this->assertEquals(3.68995, contrast_ratio($this->c, color('#ff0')));
     }
 
     /** @test */
-    function green()
+    function green(): void
     {
         $this->assertEquals(0, green($this->c));
     }
 
     /** @test */
-    function hsl()
+    function hsl(): void
     {
         foreach ([hsl(348, 100, 50), hsl('hsl(348, 100%, 50%)')] as $color) {
             $this->assertInstanceOf(C::class, $color);
@@ -77,7 +77,7 @@ class ColorsTest extends TestCase
     }
 
     /** @test */
-    function hsla()
+    function hsla(): void
     {
         $colors = [
             hsla(348, 100, 50, 0.7),
@@ -92,70 +92,70 @@ class ColorsTest extends TestCase
     }
 
     /** @test */
-    function hue()
+    function hue(): void
     {
         $this->assertEquals(348, hue($this->c));
     }
 
     /** @test */
-    function is_bright()
+    function is_bright(): void
     {
         $this->assertFalse(is_bright($this->c));
         $this->assertTrue(is_bright($this->c, 80));
     }
 
     /** @test */
-    function is_light()
+    function is_light(): void
     {
         $this->assertTrue(is_light($this->c));
         $this->assertFalse(is_light($this->c, 55));
     }
 
     /** @test */
-    function lightness()
+    function lightness(): void
     {
         $this->assertEquals(50, lightness($this->c));
     }
 
     /** @test */
-    function looks_bright()
+    function looks_bright(): void
     {
         $this->assertTrue(looks_bright($this->c));
         $this->assertFalse(looks_bright($this->c, 150));
     }
 
     /** @test */
-    function name()
+    function name(): void
     {
         $this->assertEquals('white', name(ColorFactory::fromString('#ffffff')));
     }
 
     /** @test */
-    function opacity()
+    function opacity(): void
     {
         $this->assertEquals(0.7, opacity($this->c));
     }
 
     /** @test */
-    function perceived_brightness()
+    function perceived_brightness(): void
     {
         $this->assertEquals(140.49551, perceived_brightness($this->c));
     }
 
     /** @test */
-    function red()
+    function red(): void
     {
         $this->assertEquals(255, red($this->c));
     }
 
     /** @test */
-    function relative_luminance()
+    function relative_luminance(): void
     {
         $this->assertEquals(0.21499, relative_luminance($this->c));
     }
 
     /** @test */
-    function rgb()
+    function rgb(): void
     {
         foreach ([rgb(255, 0, 51), rgb('rgb(255, 0, 51)')] as $color) {
             $this->assertInstanceOf(C::class, $color);
@@ -163,7 +163,7 @@ class ColorsTest extends TestCase
     }
 
     /** @test */
-    function rgba()
+    function rgba(): void
     {
         $colors = [
             rgba(255, 0, 51, 0.7),
@@ -178,7 +178,7 @@ class ColorsTest extends TestCase
     }
 
     /** @test */
-    function saturation()
+    function saturation(): void
     {
         $this->assertEquals(100, saturation($this->c));
     }

--- a/tests/Converters/HslToRgbTest.php
+++ b/tests/Converters/HslToRgbTest.php
@@ -15,7 +15,7 @@ class HslToRgbTest extends TestCase
     }
 
     /** @test */
-    function it_can_convert_hsl_and_hsla()
+    function it_can_convert_hsl_and_hsla(): void
     {
         $hsl = new Hsl(348, 100, 50);
         $hsla = new Hsla(348, 100, 50, 0.7);
@@ -33,7 +33,7 @@ class HslToRgbTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_handles_each_step_of_conversion()
+    function it_correctly_handles_each_step_of_conversion(): void
     {
         // Step 1 - zero saturation.
         $hsl = new Hsl(0, 0, 83);

--- a/tests/Converters/HslToRgbTest.php
+++ b/tests/Converters/HslToRgbTest.php
@@ -9,7 +9,7 @@ use SSNepenthe\ColorUtils\Converters\HslToRgb;
 
 class HslToRgbTest extends TestCase
 {
-    function set_up()
+    function set_up(): void
     {
         $this->c = new HslToRgb;
     }

--- a/tests/Converters/RgbToHslTest.php
+++ b/tests/Converters/RgbToHslTest.php
@@ -15,7 +15,7 @@ class RgbToHslTest extends TestCase
     }
 
     /** @test */
-    function it_can_convert_rgb_and_rgba()
+    function it_can_convert_rgb_and_rgba(): void
     {
         $rgb = new Rgb(255, 0, 51);
         $rgba = new Rgba(255, 0, 51, 0.7);
@@ -32,7 +32,7 @@ class RgbToHslTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_handles_each_step_of_conversion()
+    function it_correctly_handles_each_step_of_conversion(): void
     {
         // Step 4 - Shades of gray.
         $rgb = new Rgb(100, 100, 100);

--- a/tests/Converters/RgbToHslTest.php
+++ b/tests/Converters/RgbToHslTest.php
@@ -9,7 +9,7 @@ use SSNepenthe\ColorUtils\Converters\RgbToHsl;
 
 class RgbToHslTest extends TestCase
 {
-    function set_up()
+    function set_up(): void
     {
         $this->c = new RgbToHsl;
     }

--- a/tests/Exceptions/BadMethodCallExceptionTest.php
+++ b/tests/Exceptions/BadMethodCallExceptionTest.php
@@ -7,7 +7,7 @@ use SSNepenthe\ColorUtils\Exceptions\BadMethodCallException;
 class BadMethodCallExceptionTest extends TestCase
 {
     /** @test */
-    function it_reflects_expected_hierarchy()
+    function it_reflects_expected_hierarchy(): void
     {
         $e = new BadMethodCallException('test');
 

--- a/tests/Exceptions/InvalidArgumentExceptionTest.php
+++ b/tests/Exceptions/InvalidArgumentExceptionTest.php
@@ -7,7 +7,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class InvalidArgumentExceptionTest extends TestCase
 {
     /** @test */
-    function it_reflects_expected_hierarchy()
+    function it_reflects_expected_hierarchy(): void
     {
         $e = new InvalidArgumentException('test');
 

--- a/tests/Exceptions/LogicExceptionTest.php
+++ b/tests/Exceptions/LogicExceptionTest.php
@@ -7,7 +7,7 @@ use SSNepenthe\ColorUtils\Exceptions\ExceptionInterface;
 class LogicExceptionTest extends TestCase
 {
     /** @test */
-    function it_reflects_expected_hierarchy()
+    function it_reflects_expected_hierarchy(): void
     {
         $e = new LogicException('test');
 

--- a/tests/Exceptions/RuntimeExceptionTest.php
+++ b/tests/Exceptions/RuntimeExceptionTest.php
@@ -7,7 +7,7 @@ use SSNepenthe\ColorUtils\Exceptions\ExceptionInterface;
 class RuntimeExceptionTest extends TestCase
 {
     /** @test */
-    function it_reflects_expected_hierarchy()
+    function it_reflects_expected_hierarchy(): void
     {
         $e = new RuntimeException('test');
 

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -10,7 +10,7 @@ use function SSNepenthe\ColorUtils\array_contains_one_of;
 class HelpersTest extends TestCase
 {
     /** @test */
-    function it_correctly_determines_if_array_contains_all_given_keys()
+    function it_correctly_determines_if_array_contains_all_given_keys(): void
     {
         $arr = ['one' => 1, 'two' => 2, 'three' => 3];
 
@@ -25,7 +25,7 @@ class HelpersTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_determines_if_array_contains_one_of_given_keys()
+    function it_correctly_determines_if_array_contains_one_of_given_keys(): void
     {
         $arr = ['one' => 1, 'two' => 2, 'three' => 3];
 
@@ -40,7 +40,7 @@ class HelpersTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_performs_x_mod_y()
+    function it_correctly_performs_x_mod_y(): void
     {
         // In range.
         $this->assertSame(75.0, modulo(75, 100));
@@ -57,7 +57,7 @@ class HelpersTest extends TestCase
     }
 
     /** @test */
-    function it_restricts_value_to_given_range()
+    function it_restricts_value_to_given_range(): void
     {
         // In range.
         $this->assertEquals(25, restrict(25, 0, 100));
@@ -72,7 +72,7 @@ class HelpersTest extends TestCase
     }
 
     /** @test */
-    function it_can_tell_if_value_is_in_range_inclusive()
+    function it_can_tell_if_value_is_in_range_inclusive(): void
     {
         $this->assertTrue(value_is_between(25, 0, 50));
         $this->assertFalse(value_is_between(25, 50, 100));

--- a/tests/Parsers/DelegatingParserTest.php
+++ b/tests/Parsers/DelegatingParserTest.php
@@ -9,7 +9,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class DelegatingParserTest extends TestCase
 {
     /** @test */
-    function it_is_instantiable()
+    function it_is_instantiable(): void
     {
         $resolverStub = $this->createMock(ParserResolverInterface::class);
         $parser = new DelegatingParser($resolverStub);
@@ -18,7 +18,7 @@ class DelegatingParserTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_delegates_to_resolver_to_check_support()
+    function it_correctly_delegates_to_resolver_to_check_support(): void
     {
         $supported = '#abcdef';
         $unsupported = 'rgb(120, 120, 120)';
@@ -35,7 +35,7 @@ class DelegatingParserTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_delegates_to_resolver_to_parse_colors()
+    function it_correctly_delegates_to_resolver_to_parse_colors(): void
     {
         $toParse = '#abcdef';
         $parsed = ['red' => 173, 'green' => 205, 'blue' => 239];
@@ -54,7 +54,7 @@ class DelegatingParserTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_attempting_to_parse_unsupported_string()
+    function it_throws_when_attempting_to_parse_unsupported_string(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Parsers/HexParserTest.php
+++ b/tests/Parsers/HexParserTest.php
@@ -7,7 +7,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class HexParserTest extends TestCase
 {
     /** @test */
-    function it_knows_whether_it_can_parse_a_given_string()
+    function it_knows_whether_it_can_parse_a_given_string(): void
     {
         $parser = new HexParser;
 
@@ -34,7 +34,7 @@ class HexParserTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_parses_rgb_hex_strings()
+    function it_correctly_parses_rgb_hex_strings(): void
     {
         $parser = new HexParser;
 
@@ -47,7 +47,7 @@ class HexParserTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_parses_rgba_hex_strings()
+    function it_correctly_parses_rgba_hex_strings(): void
     {
         $parser = new HexParser;
 
@@ -58,7 +58,7 @@ class HexParserTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_attempting_to_parse_unsupported_string()
+    function it_throws_when_attempting_to_parse_unsupported_string(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Parsers/HslParserTest.php
+++ b/tests/Parsers/HslParserTest.php
@@ -7,7 +7,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class HslParserTest extends TestCase
 {
     /** @test */
-    function it_knows_whether_it_can_parse_a_given_string()
+    function it_knows_whether_it_can_parse_a_given_string(): void
     {
         $parser = new HslParser;
 
@@ -103,7 +103,7 @@ class HslParserTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_parses_hsla_strings()
+    function it_correctly_parses_hsla_strings(): void
     {
         $parser = new HslParser;
 
@@ -114,7 +114,7 @@ class HslParserTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_attempting_to_parse_unsupported_string()
+    function it_throws_when_attempting_to_parse_unsupported_string(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Parsers/HslaParserTest.php
+++ b/tests/Parsers/HslaParserTest.php
@@ -7,7 +7,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class HslaParserTest extends TestCase
 {
     /** @test */
-    function it_knows_whether_it_can_parse_a_given_string()
+    function it_knows_whether_it_can_parse_a_given_string(): void
     {
         $parser = new HslaParser;
 
@@ -161,7 +161,7 @@ class HslaParserTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_parses_hsla_strings()
+    function it_correctly_parses_hsla_strings(): void
     {
         $parser = new HslaParser;
 
@@ -172,7 +172,7 @@ class HslaParserTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_attempting_to_parse_unsupported_string()
+    function it_throws_when_attempting_to_parse_unsupported_string(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Parsers/KeywordParserTest.php
+++ b/tests/Parsers/KeywordParserTest.php
@@ -8,7 +8,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class KeywordParserTest extends TestCase
 {
     /** @test */
-    function it_knows_whether_it_can_parse_a_given_string()
+    function it_knows_whether_it_can_parse_a_given_string(): void
     {
         $parser = new KeywordParser($this->createMock(HexParser::class));
 
@@ -18,7 +18,7 @@ class KeywordParserTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_delegates_to_hex_parser()
+    function it_correctly_delegates_to_hex_parser(): void
     {
         $hexParserStub = $this->createMock(HexParser::class);
         $hexParserStub->method('parse')
@@ -36,7 +36,7 @@ class KeywordParserTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_attempting_to_parse_unsupported_string()
+    function it_throws_when_attempting_to_parse_unsupported_string(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $hexParserMock = $this->createMock(HexParser::class);

--- a/tests/Parsers/ParserResolverTest.php
+++ b/tests/Parsers/ParserResolverTest.php
@@ -8,7 +8,7 @@ use SSNepenthe\ColorUtils\Parsers\ParserResolverInterface;
 class ParserResolverTest extends TestCase
 {
     /** @test */
-    function it_is_intantiable()
+    function it_is_intantiable(): void
     {
         $resolver = new ParserResolver([$this->createMock(ParserInterface::class)]);
 
@@ -16,7 +16,7 @@ class ParserResolverTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_resolves_parser_based_on_support()
+    function it_correctly_resolves_parser_based_on_support(): void
     {
         $hex = '#abcdef';
         $firstParserStub = $this->createMock(ParserInterface::class);

--- a/tests/Parsers/RgbParserTest.php
+++ b/tests/Parsers/RgbParserTest.php
@@ -7,7 +7,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class RgbParserTest extends TestCase
 {
     /** @test */
-    function it_knows_whether_it_can_parse_a_given_string()
+    function it_knows_whether_it_can_parse_a_given_string(): void
     {
         $parser = new RgbParser;
 
@@ -104,7 +104,7 @@ class RgbParserTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_parses_rgba_strings()
+    function it_correctly_parses_rgba_strings(): void
     {
         $parser = new RgbParser;
 
@@ -117,7 +117,7 @@ class RgbParserTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_attempting_to_parse_unsupported_string()
+    function it_throws_when_attempting_to_parse_unsupported_string(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Parsers/RgbaParserTest.php
+++ b/tests/Parsers/RgbaParserTest.php
@@ -7,7 +7,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class RgbaParserTest extends TestCase
 {
     /** @test */
-    function it_knows_whether_it_can_parse_a_given_string()
+    function it_knows_whether_it_can_parse_a_given_string(): void
     {
         $parser = new RgbaParser;
 
@@ -125,7 +125,7 @@ class RgbaParserTest extends TestCase
     }
 
     /** @test */
-    function it_correctly_parses_rgba_strings()
+    function it_correctly_parses_rgba_strings(): void
     {
         $parser = new RgbaParser;
         $supported = ['rgba(255, 255, 255, 0.5)', 'rgba(100%, 100%, 100%, 0.5)'];
@@ -139,7 +139,7 @@ class RgbaParserTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_attempting_to_parse_unsupported_string()
+    function it_throws_when_attempting_to_parse_unsupported_string(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/TransformationsTest.php
+++ b/tests/TransformationsTest.php
@@ -10,7 +10,7 @@ use function SSNepenthe\ColorUtils\{
 class TransformationsTest extends TestCase
 {
     /** @test */
-    function adjust_color()
+    function adjust_color(): void
     {
         $this->assertEquals(
             'hsl(0, 0%, 50%)',
@@ -19,7 +19,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function adjust_hue()
+    function adjust_hue(): void
     {
         $this->assertEquals(
             'hsl(180, 0%, 0%)',
@@ -28,7 +28,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function change_color()
+    function change_color(): void
     {
         $this->assertEquals(
             'hsl(0, 0%, 50%)',
@@ -37,7 +37,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function complement()
+    function complement(): void
     {
         $this->assertEquals(
             'hsl(180, 0%, 0%)',
@@ -46,7 +46,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function darken()
+    function darken(): void
     {
         $this->assertEquals(
             'hsl(0, 0%, 70%)',
@@ -55,7 +55,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function desaturate()
+    function desaturate(): void
     {
         $this->assertEquals(
             'hsl(0, 95%, 50%)',
@@ -64,7 +64,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function grayscale()
+    function grayscale(): void
     {
         $this->assertEquals(
             'hsl(0, 0%, 50%)',
@@ -73,7 +73,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function invert()
+    function invert(): void
     {
         $this->assertEquals(
             'rgb(255, 255, 255)',
@@ -82,7 +82,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function lighten()
+    function lighten(): void
     {
         $this->assertEquals(
             'hsl(0, 0%, 50%)',
@@ -91,7 +91,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function mix()
+    function mix(): void
     {
         $this->assertEquals(
             'rgb(128, 0, 128)',
@@ -100,7 +100,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function opacify_and_fade_in()
+    function opacify_and_fade_in(): void
     {
         $c = ColorFactory::fromRgba(0, 0, 0, 0);
         $functions = [
@@ -114,7 +114,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function saturate()
+    function saturate(): void
     {
         $this->assertEquals(
             'hsl(0, 50%, 0%)',
@@ -123,7 +123,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function scale_color()
+    function scale_color(): void
     {
         $this->assertEquals(
             'hsl(0, 0%, 50%)',
@@ -132,7 +132,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function shade()
+    function shade(): void
     {
         $this->assertEquals(
             'rgb(128, 128, 128)',
@@ -141,7 +141,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function tint()
+    function tint(): void
     {
         $this->assertEquals(
             'rgb(128, 128, 128)',
@@ -150,7 +150,7 @@ class TransformationsTest extends TestCase
     }
 
     /** @test */
-    function transparentize_and_fade_out()
+    function transparentize_and_fade_out(): void
     {
         $c = ColorFactory::fromRgb(0, 0, 0);
         $functions = [

--- a/tests/Transformers/AdjustColorTest.php
+++ b/tests/Transformers/AdjustColorTest.php
@@ -13,7 +13,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class AdjustColorTest extends TestCase
 {
     /** @test */
-    function it_can_adjust_colors()
+    function it_can_adjust_colors(): void
     {
         $c = ColorFactory::fromHsl(120, 30, 90);
 
@@ -51,7 +51,7 @@ class AdjustColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_adjust_alpha_values()
+    function it_can_adjust_alpha_values(): void
     {
         // assert_equal(evaluate("hsla(120, 30, 90, 0.65)"),
         // evaluate("adjust-color(hsl(120, 30, 90), $alpha: -0.35)"))
@@ -70,7 +70,7 @@ class AdjustColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_adjust_multiple_attributes_at_once()
+    function it_can_adjust_multiple_attributes_at_once(): void
     {
         $c = ColorFactory::fromHsl(120, 30, 90);
 
@@ -115,7 +115,7 @@ class AdjustColorTest extends TestCase
     }
 
     /** @test */
-    function it_honors_range_restrictions()
+    function it_honors_range_restrictions(): void
     {
         // Technically restrictions are handled in the Hsl and Rgb classes...
         $c = ColorFactory::fromHsl(120, 30, 90);
@@ -154,7 +154,7 @@ class AdjustColorTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_given_non_numeric_adjustments()
+    function it_throws_when_given_non_numeric_adjustments(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -162,7 +162,7 @@ class AdjustColorTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_given_adjustments_of_zero()
+    function it_throws_when_given_adjustments_of_zero(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -170,7 +170,7 @@ class AdjustColorTest extends TestCase
     }
 
     /** @test */
-    function it_discards_invalid_channels()
+    function it_discards_invalid_channels(): void
     {
         // Basically testing that no BadMethodCallException is thrown.
         $t = new AdjustColor(['purple' => 50, 'blue' => 25]);

--- a/tests/Transformers/AdjustColorTest.php
+++ b/tests/Transformers/AdjustColorTest.php
@@ -158,7 +158,7 @@ class AdjustColorTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $t = new AdjustColor(['blue' => 'test']);
+        new AdjustColor(['blue' => 'test']);
     }
 
     /** @test */
@@ -166,7 +166,7 @@ class AdjustColorTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $t = new AdjustColor(['green' => 0]);
+        new AdjustColor(['green' => 0]);
     }
 
     /** @test */

--- a/tests/Transformers/AdjustHueTest.php
+++ b/tests/Transformers/AdjustHueTest.php
@@ -71,6 +71,6 @@ class AdjustHueTest extends TestCase
         // SASS allows this, I don't like it.
         $this->expectException(InvalidArgumentException::class);
 
-        $t = new AdjustHue(0);
+        new AdjustHue(0);
     }
 }

--- a/tests/Transformers/AdjustHueTest.php
+++ b/tests/Transformers/AdjustHueTest.php
@@ -13,7 +13,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class AdjustHueTest extends TestCase
 {
     /** @test */
-    function it_can_positively_adjust_hue()
+    function it_can_positively_adjust_hue(): void
     {
         // assert_equal("#deeded", evaluate("adjust-hue(hsl(120, 30, 90), 60deg)"))
         $t = new AdjustHue(60);
@@ -32,7 +32,7 @@ class AdjustHueTest extends TestCase
     }
 
     /** @test */
-    function it_can_negatively_adjust_hue()
+    function it_can_negatively_adjust_hue(): void
     {
         // assert_equal("#ededde", evaluate("adjust-hue(hsl(120, 30, 90), -60deg)"))
         $c = ColorFactory::fromHsl(120, 30, 90);
@@ -41,7 +41,7 @@ class AdjustHueTest extends TestCase
     }
 
     /** @test */
-    function it_cant_adjust_shades_of_gray()
+    function it_cant_adjust_shades_of_gray(): void
     {
         // assert_equal("black", evaluate("adjust-hue(#000, 45deg)"))
         $c = ColorFactory::fromString('#000');
@@ -55,7 +55,7 @@ class AdjustHueTest extends TestCase
     }
 
     /** @test */
-    function adjustments_of_360_creates_the_same_color()
+    function adjustments_of_360_creates_the_same_color(): void
     {
         $t = new AdjustHue(360);
 
@@ -66,7 +66,7 @@ class AdjustHueTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_given_invalid_adjustments()
+    function it_throws_when_given_invalid_adjustments(): void
     {
         // SASS allows this, I don't like it.
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Transformers/ChangeColorTest.php
+++ b/tests/Transformers/ChangeColorTest.php
@@ -13,7 +13,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class ChangeColorTest extends TestCase
 {
     /** @test */
-    function it_can_change_colors()
+    function it_can_change_colors(): void
     {
         $c = ColorFactory::fromHsl(120, 30, 90);
 
@@ -51,7 +51,7 @@ class ChangeColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_change_alpha_values()
+    function it_can_change_alpha_values(): void
     {
         $c = ColorFactory::fromRgb(10, 20, 30);
 
@@ -62,7 +62,7 @@ class ChangeColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_change_multiple_attributes_at_once()
+    function it_can_change_multiple_attributes_at_once(): void
     {
         $c = ColorFactory::fromHsl(120, 30, 90);
 
@@ -86,7 +86,7 @@ class ChangeColorTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_given_non_numeric_adjustments()
+    function it_throws_when_given_non_numeric_adjustments(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -94,7 +94,7 @@ class ChangeColorTest extends TestCase
     }
 
     /** @test */
-    function it_discards_invalid_channels()
+    function it_discards_invalid_channels(): void
     {
         // Basically testing that no BadMethodCallException is thrown.
         $t = new ChangeColor(['purple' => 50, 'blue' => 25]);

--- a/tests/Transformers/ChangeColorTest.php
+++ b/tests/Transformers/ChangeColorTest.php
@@ -90,7 +90,7 @@ class ChangeColorTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $t = new ChangeColor(['blue' => 'test']);
+        new ChangeColor(['blue' => 'test']);
     }
 
     /** @test */

--- a/tests/Transformers/ComplementTest.php
+++ b/tests/Transformers/ComplementTest.php
@@ -19,7 +19,7 @@ class ComplementTest extends TestCase
     }
 
     /** @test */
-    function it_can_create_complements_of_colors()
+    function it_can_create_complements_of_colors(): void
     {
         // assert_equal("#ccbbaa", evaluate("complement(#abc)"))
         $c = ColorFactory::fromString('#abc');
@@ -39,7 +39,7 @@ class ComplementTest extends TestCase
     }
 
     /** @test */
-    function it_cant_adjust_shades_of_gray()
+    function it_cant_adjust_shades_of_gray(): void
     {
         // assert_equal("white", evaluate("complement(white)"))
         $c = ColorFactory::fromString('white');

--- a/tests/Transformers/ComplementTest.php
+++ b/tests/Transformers/ComplementTest.php
@@ -13,7 +13,7 @@ class ComplementTest extends TestCase
 {
     protected $t;
 
-    function set_up()
+    function set_up(): void
     {
         $this->t = new Complement;
     }

--- a/tests/Transformers/ConditionalTransformerTest.php
+++ b/tests/Transformers/ConditionalTransformerTest.php
@@ -13,9 +13,7 @@ class ConditionalTransformerTest extends TestCase
     /** @test */
     function it_can_be_instantiated()
     {
-        $transformer = new ConditionalTransformer(function (Color $color) : bool {
-            return ! $color->looksBright();
-        }, new Lighten(30));
+        $transformer = new ConditionalTransformer(fn(Color $color): bool => ! $color->looksBright(), new Lighten(30));
 
         $this->assertInstanceOf(ConditionalTransformer::class, $transformer);
         $this->assertInstanceOf(TransformerInterface::class, $transformer);
@@ -24,9 +22,7 @@ class ConditionalTransformerTest extends TestCase
     /** @test */
     function it_can_conditionally_transform_a_color()
     {
-        $transformer = new ConditionalTransformer(function (Color $color) : bool {
-            return ! $color->looksBright();
-        }, new Lighten(30));
+        $transformer = new ConditionalTransformer(fn(Color $color): bool => ! $color->looksBright(), new Lighten(30));
 
         $color = ColorFactory::fromString('orange');
         $newColor = $transformer->transform($color);
@@ -42,9 +38,7 @@ class ConditionalTransformerTest extends TestCase
     /** @test */
     function it_can_apply_a_fallback_transformation()
     {
-        $transformer = new ConditionalTransformer(function (Color $color) : bool {
-            return ! $color->looksBright();
-        }, new Lighten(30), new Darken(30));
+        $transformer = new ConditionalTransformer(fn(Color $color): bool => ! $color->looksBright(), new Lighten(30), new Darken(30));
 
         $color = ColorFactory::fromString('orange');
         $darkened = $transformer->transform($color);

--- a/tests/Transformers/ConditionalTransformerTest.php
+++ b/tests/Transformers/ConditionalTransformerTest.php
@@ -11,7 +11,7 @@ use SSNepenthe\ColorUtils\Transformers\ConditionalTransformer;
 class ConditionalTransformerTest extends TestCase
 {
     /** @test */
-    function it_can_be_instantiated()
+    function it_can_be_instantiated(): void
     {
         $transformer = new ConditionalTransformer(fn(Color $color): bool => ! $color->looksBright(), new Lighten(30));
 
@@ -20,7 +20,7 @@ class ConditionalTransformerTest extends TestCase
     }
 
     /** @test */
-    function it_can_conditionally_transform_a_color()
+    function it_can_conditionally_transform_a_color(): void
     {
         $transformer = new ConditionalTransformer(fn(Color $color): bool => ! $color->looksBright(), new Lighten(30));
 
@@ -36,7 +36,7 @@ class ConditionalTransformerTest extends TestCase
     }
 
     /** @test */
-    function it_can_apply_a_fallback_transformation()
+    function it_can_apply_a_fallback_transformation(): void
     {
         $transformer = new ConditionalTransformer(fn(Color $color): bool => ! $color->looksBright(), new Lighten(30), new Darken(30));
 

--- a/tests/Transformers/DarkenTest.php
+++ b/tests/Transformers/DarkenTest.php
@@ -52,6 +52,6 @@ class DarkenTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         // assert_equal("#880000", evaluate("darken(#800, 0%)"))
-        $t = new Darken(0);
+        new Darken(0);
     }
 }

--- a/tests/Transformers/DarkenTest.php
+++ b/tests/Transformers/DarkenTest.php
@@ -13,7 +13,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class DarkenTest extends TestCase
 {
     /** @test */
-    function it_can_darken_colors()
+    function it_can_darken_colors(): void
     {
         // assert_equal("#ff6a00", evaluate("darken(hsl(25, 100, 80), 30%)"))
         $c = ColorFactory::fromHsl(25, 100, 80);
@@ -32,7 +32,7 @@ class DarkenTest extends TestCase
     }
 
     /** @test */
-    function it_can_only_go_as_dark_as_black()
+    function it_can_only_go_as_dark_as_black(): void
     {
         // assert_equal("black", evaluate("darken(#000, 20%)"))
         $c = ColorFactory::fromString('#000');
@@ -46,7 +46,7 @@ class DarkenTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_given_invalid_adjustments()
+    function it_throws_when_given_invalid_adjustments(): void
     {
         // SASS allows this, I don't like it.
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Transformers/DesaturateTest.php
+++ b/tests/Transformers/DesaturateTest.php
@@ -13,7 +13,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class DesaturateTest extends TestCase
 {
     /** @test */
-    function it_can_desaturate_colors()
+    function it_can_desaturate_colors(): void
     {
         $c = ColorFactory::fromHsl(120, 30, 90);
 
@@ -35,7 +35,7 @@ class DesaturateTest extends TestCase
     }
 
     /** @test */
-    function it_cant_desaturate_shades_of_gray()
+    function it_cant_desaturate_shades_of_gray(): void
     {
         $c = ColorFactory::fromString('#000');
 
@@ -51,7 +51,7 @@ class DesaturateTest extends TestCase
     }
 
     /** @test */
-    function it_handles_the_extremes()
+    function it_handles_the_extremes(): void
     {
         $c = ColorFactory::fromString('#8a8');
 
@@ -61,7 +61,7 @@ class DesaturateTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_given_invalid_adjustments()
+    function it_throws_when_given_invalid_adjustments(): void
     {
         // SASS allows this, I don't like it.
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Transformers/DesaturateTest.php
+++ b/tests/Transformers/DesaturateTest.php
@@ -67,6 +67,6 @@ class DesaturateTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         // assert_equal("#88aa88", evaluate("desaturate(#8a8, 0%)"))
-        $t = new Desaturate(0);
+        new Desaturate(0);
     }
 }

--- a/tests/Transformers/GrayScaleTest.php
+++ b/tests/Transformers/GrayScaleTest.php
@@ -13,7 +13,7 @@ class GrayScaleTest extends TestCase
 {
     protected $t;
 
-    function set_up()
+    function set_up(): void
     {
         $this->t = new GrayScale;
     }

--- a/tests/Transformers/GrayScaleTest.php
+++ b/tests/Transformers/GrayScaleTest.php
@@ -19,7 +19,7 @@ class GrayScaleTest extends TestCase
     }
 
     /** @test */
-    function it_can_convert_colors_to_grayscale()
+    function it_can_convert_colors_to_grayscale(): void
     {
         $c = ColorFactory::fromString('#abc');
 
@@ -39,7 +39,7 @@ class GrayScaleTest extends TestCase
     }
 
     /** @test */
-    function it_doesnt_change_shades_of_gray()
+    function it_doesnt_change_shades_of_gray(): void
     {
         $c = ColorFactory::fromString('#fff');
 
@@ -53,7 +53,7 @@ class GrayScaleTest extends TestCase
     }
 
     /** @test */
-    function it_converts_primary_colors_straight_to_gray()
+    function it_converts_primary_colors_straight_to_gray(): void
     {
         $c = ColorFactory::fromString('#f00');
 

--- a/tests/Transformers/InvertTest.php
+++ b/tests/Transformers/InvertTest.php
@@ -13,7 +13,7 @@ class InvertTest extends TestCase
 {
     protected $t;
 
-    function set_up()
+    function set_up(): void
     {
         $this->t = new Invert;
     }

--- a/tests/Transformers/InvertTest.php
+++ b/tests/Transformers/InvertTest.php
@@ -19,7 +19,7 @@ class InvertTest extends TestCase
     }
 
     /** @test */
-    function it_can_invert_colors()
+    function it_can_invert_colors(): void
     {
         $c = ColorFactory::fromString('#edc');
 

--- a/tests/Transformers/LightenTest.php
+++ b/tests/Transformers/LightenTest.php
@@ -55,6 +55,6 @@ class LightenTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         // assert_equal("#880000", evaluate("lighten(#800, 0%)"))
-        $t = new Lighten(0);
+        new Lighten(0);
     }
 }

--- a/tests/Transformers/LightenTest.php
+++ b/tests/Transformers/LightenTest.php
@@ -13,7 +13,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class LightenTest extends TestCase
 {
     /** @test */
-    function it_can_lighten_colors()
+    function it_can_lighten_colors(): void
     {
         $c = ColorFactory::fromString('#800');
 
@@ -39,7 +39,7 @@ class LightenTest extends TestCase
     }
 
     /** @test */
-    function it_can_only_go_as_light_as_white()
+    function it_can_only_go_as_light_as_white(): void
     {
         $c = ColorFactory::fromString('white');
 
@@ -49,7 +49,7 @@ class LightenTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_given_invalid_adjustments()
+    function it_throws_when_given_invalid_adjustments(): void
     {
         // SASS allows this, I don't like it.
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Transformers/MixTest.php
+++ b/tests/Transformers/MixTest.php
@@ -12,7 +12,7 @@ use SSNepenthe\ColorUtils\Colors\ColorFactory;
 class MixTest extends TestCase
 {
     /** @test */
-    function it_can_mix_colors()
+    function it_can_mix_colors(): void
     {
         // assert_equal("purple", evaluate("mix(#f00, #00f)"))
         $t = new Mix(ColorFactory::fromString('#f00'));
@@ -58,7 +58,7 @@ class MixTest extends TestCase
     }
 
     /** @test */
-    function it_can_mix_colors_with_alpha()
+    function it_can_mix_colors_with_alpha(): void
     {
         // assert_equal("rgba(64, 0, 191, 0.75)", evaluate("mix(rgba(255, 0, 0, 0.5), #00f)"))
         $t = new Mix(ColorFactory::fromRgba(255, 0, 0, 0.5));

--- a/tests/Transformers/OpacifyTest.php
+++ b/tests/Transformers/OpacifyTest.php
@@ -43,6 +43,6 @@ class OpacifyTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         // assert_equal("rgba(0, 0, 0, 0.2)", evaluate("opacify(rgba(0, 0, 0, 0.2), 0%)"))
-        $t = new Opacify(0.0);
+        new Opacify(0.0);
     }
 }

--- a/tests/Transformers/OpacifyTest.php
+++ b/tests/Transformers/OpacifyTest.php
@@ -13,7 +13,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class OpacifyTest extends TestCase
 {
     /** @test */
-    function it_can_add_opacity_to_colors()
+    function it_can_add_opacity_to_colors(): void
     {
         $c = ColorFactory::fromRgba(0, 0, 0, 0.2);
 
@@ -37,7 +37,7 @@ class OpacifyTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_given_invalid_adjustments()
+    function it_throws_when_given_invalid_adjustments(): void
     {
         // SASS allows this, I don't like it.
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Transformers/SaturateTest.php
+++ b/tests/Transformers/SaturateTest.php
@@ -64,6 +64,6 @@ class SaturateTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         // assert_equal("#88aa88", evaluate("saturate(#8a8, 0%)"))
-        $t = new Saturate(0);
+        new Saturate(0);
     }
 }

--- a/tests/Transformers/SaturateTest.php
+++ b/tests/Transformers/SaturateTest.php
@@ -13,7 +13,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class SaturateTest extends TestCase
 {
     /** @test */
-    function it_can_saturate_colors()
+    function it_can_saturate_colors(): void
     {
         // assert_equal("#d9f2d9", evaluate("saturate(hsl(120, 30, 90), 20%)"))
         $c = ColorFactory::fromHsl(120, 30, 90);
@@ -32,7 +32,7 @@ class SaturateTest extends TestCase
     }
 
     /** @test */
-    function saturating_shades_of_gray_doesnt_change_the_color()
+    function saturating_shades_of_gray_doesnt_change_the_color(): void
     {
         $c = ColorFactory::fromString('#000');
 
@@ -48,7 +48,7 @@ class SaturateTest extends TestCase
     }
 
     /** @test */
-    function it_honors_ranges_when_saturating_colors()
+    function it_honors_ranges_when_saturating_colors(): void
     {
         $c = ColorFactory::fromString('#8a8');
 
@@ -58,7 +58,7 @@ class SaturateTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_given_invalid_adjustments()
+    function it_throws_when_given_invalid_adjustments(): void
     {
         // SASS allows this, I don't like it.
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Transformers/ScaleColorTest.php
+++ b/tests/Transformers/ScaleColorTest.php
@@ -13,7 +13,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class ScaleColorTest extends TestCase
 {
     /** @test */
-    function it_can_scale_colors()
+    function it_can_scale_colors(): void
     {
         $c = ColorFactory::fromHsl(120, 30, 90);
 
@@ -64,7 +64,7 @@ class ScaleColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_scale_multiple_attributes()
+    function it_can_scale_multiple_attributes(): void
     {
         $c = ColorFactory::fromHsl(120, 30, 90);
 
@@ -102,7 +102,7 @@ class ScaleColorTest extends TestCase
     }
 
     /** @test */
-    function it_can_handle_extremes()
+    function it_can_handle_extremes(): void
     {
         $c = ColorFactory::fromHsl(120, 30, 90);
 
@@ -123,7 +123,7 @@ class ScaleColorTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_given_non_numeric_adjustments()
+    function it_throws_when_given_non_numeric_adjustments(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -131,7 +131,7 @@ class ScaleColorTest extends TestCase
     }
 
     /** @test */
-    function it_discards_invalid_channels()
+    function it_discards_invalid_channels(): void
     {
         // Basically testing that no BadMethodCallException is thrown.
         $t = new ScaleColor(['purple' => 50, 'blue' => 25]);

--- a/tests/Transformers/ScaleColorTest.php
+++ b/tests/Transformers/ScaleColorTest.php
@@ -127,7 +127,7 @@ class ScaleColorTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $t = new ScaleColor(['saturation' => 'test']);
+        new ScaleColor(['saturation' => 'test']);
     }
 
     /** @test */

--- a/tests/Transformers/ShadeTest.php
+++ b/tests/Transformers/ShadeTest.php
@@ -12,7 +12,7 @@ use SSNepenthe\ColorUtils\Colors\ColorFactory;
 class ShadeTest extends TestCase
 {
     /** @test */
-    function shading_white_gives_gray()
+    function shading_white_gives_gray(): void
     {
         $c = ColorFactory::fromString('#fff');
 
@@ -24,7 +24,7 @@ class ShadeTest extends TestCase
     }
 
     /** @test */
-    function shading_black_gives_black()
+    function shading_black_gives_black(): void
     {
         $c = ColorFactory::fromString('#000');
 
@@ -38,7 +38,7 @@ class ShadeTest extends TestCase
     }
 
     /** @test */
-    function it_can_shade_colors()
+    function it_can_shade_colors(): void
     {
         // .shade-red {
         //   color: shade(#f00, 25%); // #bf0000

--- a/tests/Transformers/TintTest.php
+++ b/tests/Transformers/TintTest.php
@@ -12,7 +12,7 @@ use SSNepenthe\ColorUtils\Colors\ColorFactory;
 class TintTest extends TestCase
 {
     /** @test */
-    function tinting_white_just_gives_white()
+    function tinting_white_just_gives_white(): void
     {
         // .tint-white {
         //   color: tint(#fff, 75%); // white
@@ -23,7 +23,7 @@ class TintTest extends TestCase
     }
 
     /** @test */
-    function it_can_tint_colors()
+    function it_can_tint_colors(): void
     {
         // .tint-black {
         //   color: tint(#000, 50%); // gray

--- a/tests/Transformers/TransformerPipelineTest.php
+++ b/tests/Transformers/TransformerPipelineTest.php
@@ -12,7 +12,7 @@ use SSNepenthe\ColorUtils\Transformers\TransformerInterface;
 class TransformerPipelineTest extends TestCase
 {
     /** @test */
-    function it_can_be_instantiated()
+    function it_can_be_instantiated(): void
     {
         $pipeline = new TransformerPipeline;
 
@@ -21,7 +21,7 @@ class TransformerPipelineTest extends TestCase
     }
 
     /** @test */
-    function it_can_add_transformers()
+    function it_can_add_transformers(): void
     {
         $pipeline = new TransformerPipeline;
         $lighten30 = new Lighten(30);
@@ -36,7 +36,7 @@ class TransformerPipelineTest extends TestCase
     }
 
     /** @test */
-    function it_can_be_isntantiated_with_transformers()
+    function it_can_be_isntantiated_with_transformers(): void
     {
         $lighten30 = new Lighten(30);
         $pipeline = new TransformerPipeline([$lighten30]);
@@ -49,7 +49,7 @@ class TransformerPipelineTest extends TestCase
     }
 
     /** @test */
-    function it_can_transform_a_color()
+    function it_can_transform_a_color(): void
     {
         $pipeline = new TransformerPipeline([new Lighten(30)]);
         $color = $pipeline->transform(ColorFactory::fromString('green'));
@@ -59,7 +59,7 @@ class TransformerPipelineTest extends TestCase
     }
 
     /** @test */
-    function it_transforms_colors_in_the_order_transformers_were_added()
+    function it_transforms_colors_in_the_order_transformers_were_added(): void
     {
         $invert = new Invert;
         $shade25 = new Shade(25);

--- a/tests/Transformers/TransparentizeTest.php
+++ b/tests/Transformers/TransparentizeTest.php
@@ -13,7 +13,7 @@ use SSNepenthe\ColorUtils\Exceptions\InvalidArgumentException;
 class TransparentizeTest extends TestCase
 {
     /** @test */
-    function it_can_add_transparency_to_colors()
+    function it_can_add_transparency_to_colors(): void
     {
         $t = new Transparentize(0.2);
 
@@ -50,7 +50,7 @@ class TransparentizeTest extends TestCase
     }
 
     /** @test */
-    function it_throws_when_invalid_adjustments_provided()
+    function it_throws_when_invalid_adjustments_provided(): void
     {
         // SASS allows this, I don't like it.
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Transformers/TransparentizeTest.php
+++ b/tests/Transformers/TransparentizeTest.php
@@ -56,6 +56,6 @@ class TransparentizeTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         // assert_equal("rgba(0, 0, 0, 0.2)", evaluate("transparentize(rgba(0, 0, 0, 0.2), 0)"))
-        $t = new Transparentize(0);
+        new Transparentize(0);
     }
 }


### PR DESCRIPTION
Also addresses deprecated implicitly nullable params for PHP 8.4.

Closes #13. Closes #17.